### PR TITLE
fix(zig): add Windows platform support

### DIFF
--- a/zig/src/coding_agent/auth/auth.zig
+++ b/zig/src/coding_agent/auth/auth.zig
@@ -732,7 +732,9 @@ fn executeShellCommand(allocator: std.mem.Allocator, io: std.Io, command: []cons
     }
 
     // Execute command using std.process.spawn
-    const argv = [_][]const u8{ "/bin/sh", "-c", command };
+    const builtin = @import("builtin");
+    const shell: []const u8 = if (builtin.os.tag == .windows) "bash" else "/bin/sh";
+    const argv = [_][]const u8{ shell, "-c", command };
     var child = std.process.spawn(io, .{
         .argv = argv[0..],
         .stdin = .ignore,
@@ -748,11 +750,12 @@ fn executeShellCommand(allocator: std.mem.Allocator, io: std.Io, command: []cons
     if (term == .exited and term.exited == 0) {
         if (child.stdout) |stdout_file| {
             // Read output in fixed buffer and trim
-            var buffer: [8192]u8 = undefined;
-            const bytes_read = std.posix.read(stdout_file.handle, &buffer) catch 0;
+            var read_buf: [8192]u8 = undefined;
+            var reader = stdout_file.reader(io, &read_buf);
+            const bytes_read = reader.interface.readSliceShort(&read_buf) catch 0;
             if (bytes_read > 0) {
                 // Trim whitespace
-                const trimmed = std.mem.trim(u8, buffer[0..bytes_read], &std.ascii.whitespace);
+                const trimmed = std.mem.trim(u8, read_buf[0..bytes_read], &std.ascii.whitespace);
                 if (trimmed.len > 0) {
                     result = allocator.dupe(u8, trimmed) catch return null;
                 }

--- a/zig/src/coding_agent/extensions/extension_host.zig
+++ b/zig/src/coding_agent/extensions/extension_host.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const enforcement = @import("enforcement.zig");
 const extension_registry = @import("extension_registry.zig");
 const extension_protocol = @import("extension_protocol.zig");
@@ -61,7 +62,7 @@ pub const HostProcess = struct {
             .stdin = .pipe,
             .stdout = .pipe,
             .stderr = .ignore,
-            .pgid = 0,
+            .pgid = null,
         });
         errdefer if (child.id != null) child.kill(io);
 
@@ -278,18 +279,24 @@ pub const HostProcess = struct {
         self.mutex.lockUncancelable(self.io);
         defer self.mutex.unlock(self.io);
         const file = self.stdin_file orelse return;
-        const fd = file.handle;
-        // Set O_NONBLOCK on the fd temporarily so a full pipe drops the event
-        // rather than blocking the agent loop.
-        const nonblock_mask: u32 = @bitCast(std.posix.O{ .NONBLOCK = true });
-        const prev_flags: c_int = std.c.fcntl(fd, std.c.F.GETFL, @as(c_int, 0));
-        if (prev_flags == -1) return;
-        defer _ = std.c.fcntl(fd, std.c.F.SETFL, prev_flags);
-        _ = std.c.fcntl(fd, std.c.F.SETFL, prev_flags | @as(c_int, @intCast(nonblock_mask)));
-        // Best-effort write of frame + newline. EAGAIN (pipe full) or any other
-        // error means the event is dropped.
-        _ = std.c.write(fd, frame_json.ptr, frame_json.len);
-        _ = std.c.write(fd, "\n", 1);
+        if (builtin.os.tag == .windows) {
+            // On Windows, write directly — pipe semantics differ from POSIX.
+            _ = file.writeStreamingAll(self.io, frame_json) catch return;
+            _ = file.writeStreamingAll(self.io, "\n") catch return;
+        } else {
+            const fd = file.handle;
+            // Set O_NONBLOCK on the fd temporarily so a full pipe drops the event
+            // rather than blocking the agent loop.
+            const nonblock_mask: u32 = @bitCast(std.posix.O{ .NONBLOCK = true });
+            const prev_flags: c_int = std.c.fcntl(fd, std.c.F.GETFL, @as(c_int, 0));
+            if (prev_flags == -1) return;
+            defer _ = std.c.fcntl(fd, std.c.F.SETFL, prev_flags);
+            _ = std.c.fcntl(fd, std.c.F.SETFL, prev_flags | @as(c_int, @intCast(nonblock_mask)));
+            // Best-effort write of frame + newline. EAGAIN (pipe full) or any other
+            // error means the event is dropped.
+            _ = std.c.write(fd, frame_json.ptr, frame_json.len);
+            _ = std.c.write(fd, "\n", 1);
+        }
     }
 
     fn sendInitialize(self: *HostProcess, initialize: InitializeFrame) !void {
@@ -323,8 +330,12 @@ pub const HostProcess = struct {
 
     fn killProcessGroup(self: *HostProcess) void {
         if (self.child.id) |pid| {
-            std.posix.kill(-pid, .TERM) catch {};
-            std.posix.kill(-pid, .KILL) catch {};
+            if (builtin.os.tag == .windows) {
+                _ = std.os.windows.ntdll.NtTerminateProcess(pid, @enumFromInt(@as(u32, 1)));
+            } else {
+                std.posix.kill(-pid, .TERM) catch {};
+                std.posix.kill(-pid, .KILL) catch {};
+            }
         }
     }
 };
@@ -356,7 +367,8 @@ fn readerMain(host: *HostProcess) void {
     var buffer: [4096]u8 = undefined;
     while (true) {
         const file = host.stdout_file orelse break;
-        const bytes_read = std.posix.read(file.handle, &buffer) catch |err| {
+        var reader = file.reader(host.io, &buffer);
+        const bytes_read = reader.interface.readSliceShort(&buffer) catch |err| {
             host.reader_err = err;
             break;
         };

--- a/zig/src/coding_agent/extensions/wasm/wasm_manifest.zig
+++ b/zig/src/coding_agent/extensions/wasm/wasm_manifest.zig
@@ -1134,6 +1134,9 @@ fn pathWithin(root: []const u8, candidate: []const u8) bool {
 }
 
 fn realpathAlloc(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
+    if (@import("builtin").os.tag == .windows) {
+        return std.fs.path.resolve(allocator, &.{path}) catch return error.FileNotFound;
+    }
     const z_path = try allocator.dupeZ(u8, path);
     defer allocator.free(z_path);
     var buffer: [std.Io.Dir.max_path_bytes]u8 = undefined;

--- a/zig/src/coding_agent/interactive_mode/input_dispatch.zig
+++ b/zig/src/coding_agent/interactive_mode/input_dispatch.zig
@@ -1108,6 +1108,12 @@ pub fn freeOwnedSelectItems(allocator: std.mem.Allocator, items: []tui.SelectIte
 }
 
 pub fn pollForInput() !bool {
+    if (@import("builtin").os.tag == .windows) {
+        const stdin_handle = std.Io.File.stdin().handle;
+        const timeout: std.os.windows.LARGE_INTEGER = -@as(i64, 50) * 10000; // 50ms
+        const status = std.os.windows.ntdll.NtWaitForSingleObject(stdin_handle, .FALSE, &timeout);
+        return status == .SUCCESS;
+    }
     var fds = [_]std.posix.pollfd{
         .{
             .fd = 0,

--- a/zig/src/coding_agent/interactive_mode/session_overlay.zig
+++ b/zig/src/coding_agent/interactive_mode/session_overlay.zig
@@ -410,6 +410,9 @@ fn pathsEqualCanonical(allocator: std.mem.Allocator, lhs: []const u8, rhs: []con
 }
 
 fn realpathAllocOrNull(allocator: std.mem.Allocator, path: []const u8) ?[]u8 {
+    if (@import("builtin").os.tag == .windows) {
+        return std.fs.path.resolve(allocator, &.{path}) catch return null;
+    }
     const z_path = allocator.dupeZ(u8, path) catch return null;
     defer allocator.free(z_path);
     var buffer: [std.Io.Dir.max_path_bytes]u8 = undefined;

--- a/zig/src/coding_agent/modes/mcp_stdio.zig
+++ b/zig/src/coding_agent/modes/mcp_stdio.zig
@@ -401,7 +401,7 @@ pub const StdioClient = struct {
             .stdin = .pipe,
             .stdout = .pipe,
             .stderr = .ignore,
-            .pgid = 0,
+            .pgid = null,
         });
         errdefer if (child.id != null) child.kill(io);
 
@@ -463,8 +463,12 @@ pub const StdioClient = struct {
 
     fn killProcessGroup(self: *StdioClient) void {
         if (self.child.id) |pid| {
-            std.posix.kill(-pid, .TERM) catch {};
-            std.posix.kill(-pid, .KILL) catch {};
+            if (@import("builtin").os.tag == .windows) {
+                _ = std.os.windows.ntdll.NtTerminateProcess(pid, @enumFromInt(@as(u32, 1)));
+            } else {
+                std.posix.kill(-pid, .TERM) catch {};
+                std.posix.kill(-pid, .KILL) catch {};
+            }
         }
     }
 
@@ -476,6 +480,38 @@ pub const StdioClient = struct {
 
     fn recvMessage(self: *StdioClient, allocator: std.mem.Allocator) ![]u8 {
         const file = self.stdout_file orelse return ProtocolError.McpTransportEof;
+
+        if (@import("builtin").os.tag == .windows) {
+            // Windows: use WaitForSingleObject for timeout + File reader for I/O
+            var line = std.ArrayList(u8).empty;
+            defer line.deinit(allocator);
+            var elapsed: u64 = 0;
+            while (elapsed <= self.response_timeout_ms) : (elapsed += 10) {
+                // Check if data is available
+                const timeout_us: std.os.windows.LARGE_INTEGER = -@as(i64, 10) * 10000; // 10ms
+                _ = std.os.windows.ntdll.NtWaitForSingleObject(file.handle, .FALSE, &timeout_us);
+
+                if (self.wait_done.load(.seq_cst)) return if (line.items.len == 0) ProtocolError.McpChildExited else ProtocolError.McpTransportEof;
+
+                var buffer: [1024]u8 = undefined;
+                var reader = file.reader(self.io, &buffer);
+                const bytes_read = reader.interface.readSliceShort(&buffer) catch |err| return err;
+                if (bytes_read == 0) {
+                    std.Io.sleep(self.io, .fromMilliseconds(10), .awake) catch {};
+                    continue;
+                }
+                if (std.mem.indexOfScalar(u8, buffer[0..bytes_read], '\n')) |newline_index| {
+                    try line.appendSlice(allocator, buffer[0..newline_index]);
+                    const raw = line.items;
+                    const trimmed = if (raw.len > 0 and raw[raw.len - 1] == '\r') raw[0 .. raw.len - 1] else raw;
+                    return try allocator.dupe(u8, trimmed);
+                }
+                try line.appendSlice(allocator, buffer[0..bytes_read]);
+            }
+            return ProtocolError.McpTransportTimeout;
+        }
+
+        // POSIX: use fcntl for non-blocking I/O
         const fd = file.handle;
         const previous_flags = std.c.fcntl(fd, std.c.F.GETFL, @as(c_int, 0));
         if (previous_flags == -1) return ProtocolError.McpTransportEof;

--- a/zig/src/coding_agent/modes/print_mode.zig
+++ b/zig/src/coding_agent/modes/print_mode.zig
@@ -26,7 +26,7 @@ const SignalGuard = struct {
     installed: bool = false,
 
     fn install(signal: *std.atomic.Value(bool)) SignalGuard {
-        if (!supportsPosixSignals()) return .{};
+        if (comptime builtin.os.tag == .windows) return .{};
 
         active_abort_signal = signal;
         const action: std.posix.Sigaction = .{
@@ -68,6 +68,7 @@ fn supportsPosixSignals() bool {
 }
 
 fn handleSigint(sig: std.posix.SIG, info: *const std.posix.siginfo_t, ctx_ptr: ?*anyopaque) callconv(.c) void {
+    if (comptime builtin.os.tag == .windows) return;
     _ = info;
     _ = ctx_ptr;
     if (sig != .INT) return;

--- a/zig/src/coding_agent/modes/ts_rpc_bash.zig
+++ b/zig/src/coding_agent/modes/ts_rpc_bash.zig
@@ -589,7 +589,8 @@ fn waitDirectBashChild(state: *BashWaitState) void {
 fn readDirectBashOutput(state: *BashOutputReaderState) void {
     var buffer: [4096]u8 = undefined;
     while (true) {
-        const bytes_read = std.posix.read(state.file.handle, &buffer) catch |err| {
+        var reader = state.file.reader(state.io, &buffer);
+        const bytes_read = reader.interface.readSliceShort(&buffer) catch |err| {
             state.err = err;
             return;
         };
@@ -601,9 +602,13 @@ fn readDirectBashOutput(state: *BashOutputReaderState) void {
     }
 }
 
-fn killDirectBashProcessGroup(pid: std.posix.pid_t) void {
-    std.posix.kill(-pid, .TERM) catch {};
-    std.posix.kill(-pid, .KILL) catch {};
+fn killDirectBashProcessGroup(pid: std.process.Child.Id) void {
+    if (@import("builtin").os.tag == .windows) {
+        _ = std.os.windows.ntdll.NtTerminateProcess(pid, @enumFromInt(@as(u32, 1)));
+    } else {
+        std.posix.kill(-pid, .TERM) catch {};
+        std.posix.kill(-pid, .KILL) catch {};
+    }
 }
 
 pub fn runDirectBash(
@@ -625,16 +630,29 @@ pub fn runDirectBash(
     };
     defer cwd_dir.close(io);
 
-    const wrapped_command = try std.fmt.allocPrint(allocator, "exec 2>&1\n{s}", .{command});
-    defer allocator.free(wrapped_command);
-    const argv = [_][]const u8{ "/bin/sh", "-c", wrapped_command };
+    const builtin = @import("builtin");
+    var argv_buf: [3][]const u8 = undefined;
+    var argv_len: usize = 0;
+    if (builtin.os.tag == .windows) {
+        argv_buf[0] = "bash";
+        argv_buf[1] = "-c";
+        argv_buf[2] = try std.fmt.allocPrint(allocator, "exec 2>&1\n{s}", .{command});
+        argv_len = 3;
+    } else {
+        argv_buf[0] = "/bin/sh";
+        argv_buf[1] = "-c";
+        argv_buf[2] = try std.fmt.allocPrint(allocator, "exec 2>&1\n{s}", .{command});
+        argv_len = 3;
+    }
+    const argv = argv_buf[0..argv_len];
+    defer allocator.free(argv[2]);
     var child = try std.process.spawn(io, .{
-        .argv = argv[0..],
+        .argv = argv,
         .cwd = .{ .path = cwd },
         .stdin = .ignore,
         .stdout = .pipe,
         .stderr = .ignore,
-        .pgid = 0,
+        .pgid = null,
     });
     defer {
         if (child.id != null) child.kill(io);

--- a/zig/src/coding_agent/modes/ts_rpc_mode.zig
+++ b/zig/src/coding_agent/modes/ts_rpc_mode.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const ai = @import("ai");
 const agent = @import("agent");
 const ts_rpc_wire = @import("ts_rpc_wire.zig");
@@ -2302,14 +2303,21 @@ pub fn runTsRpcMode(
 }
 
 fn pollTsRpcStdin(timeout_ms: i32) !bool {
-    var fds = [_]std.posix.pollfd{
-        .{
-            .fd = 0,
-            .events = std.posix.POLL.IN,
-            .revents = 0,
-        },
-    };
-    return (try std.posix.poll(fds[0..], timeout_ms)) > 0;
+    if (builtin.os.tag == .windows) {
+        const stdin_handle = std.Io.File.stdin().handle;
+        const timeout: std.os.windows.LARGE_INTEGER = -@as(i64, @intCast(timeout_ms)) * 10000;
+        const status = std.os.windows.ntdll.NtWaitForSingleObject(stdin_handle, .FALSE, &timeout);
+        return status == .SUCCESS;
+    } else {
+        var fds = [_]std.posix.pollfd{
+            .{
+                .fd = 0,
+                .events = std.posix.POLL.IN,
+                .revents = 0,
+            },
+        };
+        return (try std.posix.poll(fds[0..], timeout_ms)) > 0;
+    }
 }
 
 fn handleTsRpcAgentEvent(context: ?*anyopaque, event: agent.AgentEvent) !void {

--- a/zig/src/coding_agent/packages/package_manager.zig
+++ b/zig/src/coding_agent/packages/package_manager.zig
@@ -2191,6 +2191,9 @@ fn packageSourceFromItem(allocator: std.mem.Allocator, item: std.json.Value) ![]
 }
 
 fn realpathOrResolved(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
+    if (@import("builtin").os.tag == .windows) {
+        return std.fs.path.resolve(allocator, &.{path}) catch allocator.dupe(u8, path);
+    }
     const z_path = try allocator.dupeZ(u8, path);
     defer allocator.free(z_path);
     var buffer: [std.Io.Dir.max_path_bytes]u8 = undefined;

--- a/zig/src/coding_agent/tools/bash.zig
+++ b/zig/src/coding_agent/tools/bash.zig
@@ -165,17 +165,29 @@ pub const BashTool = struct {
         };
         defer cwd_dir.close(self.io);
 
-        const wrapped_command = try std.fmt.allocPrint(allocator, "exec 2>&1\n{s}", .{args.command});
-        defer allocator.free(wrapped_command);
-
-        const argv = [_][]const u8{ "/bin/sh", "-c", wrapped_command };
+        const builtin = @import("builtin");
+        var argv_buf: [3][]const u8 = undefined;
+        var argv_len: usize = 0;
+        if (builtin.os.tag == .windows) {
+            argv_buf[0] = "bash";
+            argv_buf[1] = "-c";
+            argv_buf[2] = try std.fmt.allocPrint(allocator, "exec 2>&1\n{s}", .{args.command});
+            argv_len = 3;
+        } else {
+            argv_buf[0] = "/bin/sh";
+            argv_buf[1] = "-c";
+            argv_buf[2] = try std.fmt.allocPrint(allocator, "exec 2>&1\n{s}", .{args.command});
+            argv_len = 3;
+        }
+        const argv = argv_buf[0..argv_len];
+        defer allocator.free(argv[2]);
         var child = try std.process.spawn(self.io, .{
             .argv = argv[0..],
             .cwd = .{ .path = self.cwd },
             .stdin = .ignore,
             .stdout = .pipe,
             .stderr = .ignore,
-            .pgid = 0,
+            .pgid = null,
         });
         defer {
             if (child.id != null) child.kill(self.io);
@@ -422,7 +434,8 @@ const WaitState = struct {
 fn readOutputThread(state: *OutputReaderState) void {
     var buffer: [4096]u8 = undefined;
     while (true) {
-        const bytes_read = std.posix.read(state.file.handle, &buffer) catch |err| {
+        var reader = state.file.reader(state.io, &buffer);
+        const bytes_read = reader.interface.readSliceShort(&buffer) catch |err| {
             state.err = err;
             return;
         };
@@ -443,9 +456,13 @@ fn waitChildThread(state: *WaitState) void {
     state.done.store(true, .seq_cst);
 }
 
-fn killProcessGroup(pid: std.posix.pid_t) void {
-    std.posix.kill(-pid, .TERM) catch {};
-    std.posix.kill(-pid, .KILL) catch {};
+fn killProcessGroup(pid: std.process.Child.Id) void {
+    if (@import("builtin").os.tag == .windows) {
+        _ = std.os.windows.ntdll.NtTerminateProcess(pid, @enumFromInt(@as(u32, 1)));
+    } else {
+        std.posix.kill(-pid, .TERM) catch {};
+        std.posix.kill(-pid, .KILL) catch {};
+    }
 }
 
 fn exitCodeFromTerm(term: std.process.Child.Term) ?u8 {

--- a/zig/src/main.zig
+++ b/zig/src/main.zig
@@ -35,7 +35,8 @@ pub fn main(init: std.process.Init) !void {
 
     var argv = std.ArrayList([]const u8).empty;
     defer argv.deinit(init.gpa);
-    var it = init.minimal.args.iterate();
+    var it = try std.process.Args.Iterator.initAllocator(init.minimal.args, init.gpa);
+    defer it.deinit();
     _ = it.next();
     while (it.next()) |arg| {
         try argv.append(init.gpa, arg);


### PR DESCRIPTION
## Summary
- Add Windows platform compatibility across 12 source files
- Replace POSIX-specific APIs (fcntl, kill, poll) with Windows equivalents (NtTerminateProcess, NtWaitForSingleObject)
- Use `builtin.os.tag == .windows` guards to branch platform-specific code paths
- Update process spawning to use `bash` shell on Windows instead of `/bin/sh`
- Replace `pgid = 0` with `pgid = null` for Windows process group compatibility

## Changes
- `auth/auth.zig`: Platform-aware shell selection and file reader API
- `extension_host.zig`: Windows pipe I/O, process termination, non-blocking writes
- `wasm_manifest.zig`: Windows path resolution via `std.fs.path.resolve`
- `input_dispatch.zig`: Windows stdin polling via NtWaitForSingleObject
- `session_overlay.zig`: Windows path canonicalization
- `mcp_stdio.zig`: Windows process management and line-based I/O with timeout
- `print_mode.zig`, `ts_rpc_bash.zig`, `ts_rpc_mode.zig`, `bash.zig`: POSIX signal guards for Windows
- `package_manager.zig`: Windows path handling
- `main.zig`: Platform-specific initialization

## Test plan
- [ ] Verify build succeeds on Windows with `zig build`
- [ ] Verify build still works on Linux/macOS (no regression)
- [ ] Test MCP stdio client connectivity on Windows
- [ ] Test interactive mode input handling on Windows