### PR TITLE
fix(zig): Windows platform support, TUI stability, output display, and Windows CI

### DIFF
--- a/.github/workflows/zig-ci.yml
+++ b/.github/workflows/zig-ci.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     defaults:
       run:
         working-directory: zig
@@ -53,10 +53,11 @@ jobs:
           set -euo pipefail
           ZIG_VERSION=0.16.0
           case "${{ runner.os }}-${{ runner.arch }}" in
-            Linux-X64)   ARCH=x86_64-linux ;;
-            Linux-ARM64) ARCH=aarch64-linux ;;
-            macOS-X64)   ARCH=x86_64-macos ;;
-            macOS-ARM64) ARCH=aarch64-macos ;;
+            Linux-X64)     ARCH=x86_64-linux ;;
+            Linux-ARM64)   ARCH=aarch64-linux ;;
+            macOS-X64)     ARCH=x86_64-macos ;;
+            macOS-ARM64)   ARCH=aarch64-macos ;;
+            Windows-X64)   ARCH=x86_64-windows ;;
             *) echo "Unsupported runner: ${{ runner.os }}-${{ runner.arch }}" >&2; exit 1 ;;
           esac
           echo "version=${ZIG_VERSION}" >> "${GITHUB_OUTPUT}"
@@ -81,8 +82,12 @@ jobs:
           ZIG_VERSION="${{ steps.zig-package.outputs.version }}"
           ARCH="${{ steps.zig-package.outputs.arch }}"
           INSTALL_DIR="${{ steps.zig-package.outputs.install-dir }}"
-          if [ -x "${INSTALL_DIR}/zig" ]; then
-            ACTUAL_VERSION="$("${INSTALL_DIR}/zig" version)"
+          if [ -x "${INSTALL_DIR}/zig" ] || [ -x "${INSTALL_DIR}/zig.exe" ]; then
+            if [ -x "${INSTALL_DIR}/zig.exe" ]; then
+              ACTUAL_VERSION="$("${INSTALL_DIR}/zig.exe" version)"
+            else
+              ACTUAL_VERSION="$("${INSTALL_DIR}/zig" version)"
+            fi
             if [ "${ACTUAL_VERSION}" != "${ZIG_VERSION}" ]; then
               echo "Expected cached Zig ${ZIG_VERSION}, got ${ACTUAL_VERSION}" >&2
               exit 1
@@ -92,13 +97,23 @@ jobs:
             exit 0
           fi
 
-          TARBALL="zig-${ARCH}-${ZIG_VERSION}.tar.xz"
           case "${ARCH}" in
-            x86_64-linux)   EXPECTED_SHA=70e49664a74374b48b51e6f3fdfbf437f6395d42509050588bd49abe52ba3d00 ;;
-            aarch64-linux)  EXPECTED_SHA=ea4b09bfb22ec6f6c6ceac57ab63efb6b46e17ab08d21f69f3a48b38e1534f17 ;;
-            x86_64-macos)   EXPECTED_SHA=0387557ed1877bc6a2e1802c8391953baddba76081876301c522f52977b52ba7 ;;
-            aarch64-macos)  EXPECTED_SHA=b23d70deaa879b5c2d486ed3316f7eaa53e84acf6fc9cc747de152450d401489 ;;
-            *) echo "No Zig ${ZIG_VERSION} checksum configured for ${ARCH}" >&2; exit 1 ;;
+            *-windows)
+              ARCHIVE="zip"
+              TARBALL="zig-${ARCH}-${ZIG_VERSION}.zip"
+              EXPECTED_SHA=68659eb5f1e4eb1437a722f1dd889c5a322c9954607f5edcf337bc3684a75a7e
+              ;;
+            *)
+              ARCHIVE="tar"
+              TARBALL="zig-${ARCH}-${ZIG_VERSION}.tar.xz"
+              case "${ARCH}" in
+                x86_64-linux)   EXPECTED_SHA=70e49664a74374b48b51e6f3fdfbf437f6395d42509050588bd49abe52ba3d00 ;;
+                aarch64-linux)  EXPECTED_SHA=ea4b09bfb22ec6f6c6ceac57ab63efb6b46e17ab08d21f69f3a48b38e1534f17 ;;
+                x86_64-macos)   EXPECTED_SHA=0387557ed1877bc6a2e1802c8391953baddba76081876301c522f52977b52ba7 ;;
+                aarch64-macos)  EXPECTED_SHA=b23d70deaa879b5c2d486ed3316f7eaa53e84acf6fc9cc747de152450d401489 ;;
+                *) echo "No Zig ${ZIG_VERSION} checksum configured for ${ARCH}" >&2; exit 1 ;;
+              esac
+              ;;
           esac
 
           DEST="${RUNNER_TEMP}/${TARBALL}"
@@ -156,11 +171,6 @@ jobs:
                 rm -f "${SOURCE_DEST}"
                 continue
               fi
-              if ! tar -tJf "${SOURCE_DEST}" >/dev/null; then
-                echo "Archive validation failed for ${URL}" >&2
-                rm -f "${SOURCE_DEST}"
-                continue
-              fi
               mv "${SOURCE_DEST}" "${DEST}"
               DOWNLOADED=1
               break
@@ -174,12 +184,21 @@ jobs:
             exit 1
           fi
 
-          tar -tJf "${DEST}" >/dev/null
           mkdir -p "${INSTALL_DIR}"
-          tar -xJf "${DEST}" -C "${INSTALL_DIR}" --strip-components=1
-          rm -f "${DEST}"
+          if [ "${ARCHIVE}" = "zip" ]; then
+            unzip -q "${DEST}" -d "${EXTRACT_TEMP:=${RUNNER_TEMP}/zig-extract}"
+            mv "${EXTRACT_TEMP}/zig-${ARCH}-${ZIG_VERSION}/"* "${INSTALL_DIR}/"
+            rm -rf "${EXTRACT_TEMP}" "${DEST}"
+          else
+            tar -xJf "${DEST}" -C "${INSTALL_DIR}" --strip-components=1
+            rm -f "${DEST}"
+          fi
           echo "${INSTALL_DIR}" >> "${GITHUB_PATH}"
-          ACTUAL_VERSION="$("${INSTALL_DIR}/zig" version)"
+          if [ -x "${INSTALL_DIR}/zig.exe" ]; then
+            ACTUAL_VERSION="$("${INSTALL_DIR}/zig.exe" version)"
+          else
+            ACTUAL_VERSION="$("${INSTALL_DIR}/zig" version)"
+          fi
           if [ "${ACTUAL_VERSION}" != "${ZIG_VERSION}" ]; then
             echo "Expected Zig ${ZIG_VERSION}, got ${ACTUAL_VERSION}" >&2
             exit 1
@@ -197,6 +216,13 @@ jobs:
       - name: Install system tools (macOS)
         if: runner.os == 'macOS'
         run: brew install ripgrep fd
+
+      - name: Install system tools (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          choco install ripgrep fd -y
+          echo "C:\ProgramData\chocolatey\bin" >> "${GITHUB_PATH}"
 
       - name: Verify external tools
         run: |

--- a/zig/src/coding_agent/auth/auth.zig
+++ b/zig/src/coding_agent/auth/auth.zig
@@ -732,7 +732,9 @@ fn executeShellCommand(allocator: std.mem.Allocator, io: std.Io, command: []cons
     }
 
     // Execute command using std.process.spawn
-    const argv = [_][]const u8{ "/bin/sh", "-c", command };
+    const builtin = @import("builtin");
+    const shell: []const u8 = if (builtin.os.tag == .windows) "bash" else "/bin/sh";
+    const argv = [_][]const u8{ shell, "-c", command };
     var child = std.process.spawn(io, .{
         .argv = argv[0..],
         .stdin = .ignore,
@@ -748,11 +750,12 @@ fn executeShellCommand(allocator: std.mem.Allocator, io: std.Io, command: []cons
     if (term == .exited and term.exited == 0) {
         if (child.stdout) |stdout_file| {
             // Read output in fixed buffer and trim
-            var buffer: [8192]u8 = undefined;
-            const bytes_read = std.posix.read(stdout_file.handle, &buffer) catch 0;
+            var read_buf: [8192]u8 = undefined;
+            var reader = stdout_file.reader(io, &read_buf);
+            const bytes_read = reader.interface.readSliceShort(&read_buf) catch 0;
             if (bytes_read > 0) {
                 // Trim whitespace
-                const trimmed = std.mem.trim(u8, buffer[0..bytes_read], &std.ascii.whitespace);
+                const trimmed = std.mem.trim(u8, read_buf[0..bytes_read], &std.ascii.whitespace);
                 if (trimmed.len > 0) {
                     result = allocator.dupe(u8, trimmed) catch return null;
                 }

--- a/zig/src/coding_agent/extensions/extension_host.zig
+++ b/zig/src/coding_agent/extensions/extension_host.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const enforcement = @import("enforcement.zig");
 const extension_registry = @import("extension_registry.zig");
 const extension_protocol = @import("extension_protocol.zig");
@@ -61,7 +62,7 @@ pub const HostProcess = struct {
             .stdin = .pipe,
             .stdout = .pipe,
             .stderr = .ignore,
-            .pgid = 0,
+            .pgid = null,
         });
         errdefer if (child.id != null) child.kill(io);
 
@@ -278,18 +279,24 @@ pub const HostProcess = struct {
         self.mutex.lockUncancelable(self.io);
         defer self.mutex.unlock(self.io);
         const file = self.stdin_file orelse return;
-        const fd = file.handle;
-        // Set O_NONBLOCK on the fd temporarily so a full pipe drops the event
-        // rather than blocking the agent loop.
-        const nonblock_mask: u32 = @bitCast(std.posix.O{ .NONBLOCK = true });
-        const prev_flags: c_int = std.c.fcntl(fd, std.c.F.GETFL, @as(c_int, 0));
-        if (prev_flags == -1) return;
-        defer _ = std.c.fcntl(fd, std.c.F.SETFL, prev_flags);
-        _ = std.c.fcntl(fd, std.c.F.SETFL, prev_flags | @as(c_int, @intCast(nonblock_mask)));
-        // Best-effort write of frame + newline. EAGAIN (pipe full) or any other
-        // error means the event is dropped.
-        _ = std.c.write(fd, frame_json.ptr, frame_json.len);
-        _ = std.c.write(fd, "\n", 1);
+        if (builtin.os.tag == .windows) {
+            // On Windows, write directly — pipe semantics differ from POSIX.
+            _ = file.writeStreamingAll(self.io, frame_json) catch return;
+            _ = file.writeStreamingAll(self.io, "\n") catch return;
+        } else {
+            const fd = file.handle;
+            // Set O_NONBLOCK on the fd temporarily so a full pipe drops the event
+            // rather than blocking the agent loop.
+            const nonblock_mask: u32 = @bitCast(std.posix.O{ .NONBLOCK = true });
+            const prev_flags: c_int = std.c.fcntl(fd, std.c.F.GETFL, @as(c_int, 0));
+            if (prev_flags == -1) return;
+            defer _ = std.c.fcntl(fd, std.c.F.SETFL, prev_flags);
+            _ = std.c.fcntl(fd, std.c.F.SETFL, prev_flags | @as(c_int, @intCast(nonblock_mask)));
+            // Best-effort write of frame + newline. EAGAIN (pipe full) or any other
+            // error means the event is dropped.
+            _ = std.c.write(fd, frame_json.ptr, frame_json.len);
+            _ = std.c.write(fd, "\n", 1);
+        }
     }
 
     fn sendInitialize(self: *HostProcess, initialize: InitializeFrame) !void {
@@ -323,8 +330,12 @@ pub const HostProcess = struct {
 
     fn killProcessGroup(self: *HostProcess) void {
         if (self.child.id) |pid| {
-            std.posix.kill(-pid, .TERM) catch {};
-            std.posix.kill(-pid, .KILL) catch {};
+            if (builtin.os.tag == .windows) {
+                _ = std.os.windows.ntdll.NtTerminateProcess(pid, @enumFromInt(@as(u32, 1)));
+            } else {
+                std.posix.kill(-pid, .TERM) catch {};
+                std.posix.kill(-pid, .KILL) catch {};
+            }
         }
     }
 };
@@ -356,7 +367,8 @@ fn readerMain(host: *HostProcess) void {
     var buffer: [4096]u8 = undefined;
     while (true) {
         const file = host.stdout_file orelse break;
-        const bytes_read = std.posix.read(file.handle, &buffer) catch |err| {
+        var reader = file.reader(host.io, &buffer);
+        const bytes_read = reader.interface.readSliceShort(&buffer) catch |err| {
             host.reader_err = err;
             break;
         };

--- a/zig/src/coding_agent/extensions/wasm/wasm_manifest.zig
+++ b/zig/src/coding_agent/extensions/wasm/wasm_manifest.zig
@@ -1134,6 +1134,9 @@ fn pathWithin(root: []const u8, candidate: []const u8) bool {
 }
 
 fn realpathAlloc(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
+    if (@import("builtin").os.tag == .windows) {
+        return std.fs.path.resolve(allocator, &.{path}) catch return error.FileNotFound;
+    }
     const z_path = try allocator.dupeZ(u8, path);
     defer allocator.free(z_path);
     var buffer: [std.Io.Dir.max_path_bytes]u8 = undefined;

--- a/zig/src/coding_agent/interactive_mode.zig
+++ b/zig/src/coding_agent/interactive_mode.zig
@@ -364,6 +364,7 @@ pub fn runInteractiveMode(
         if (prompt_worker_active and !prompt_worker.running.load(.seq_cst)) {
             prompt_worker.join(allocator);
             prompt_worker_active = false;
+            app_state.setToolOutputExpanded(true);
             if (should_exit) break;
         }
         installSessionUiCallbacks(&bootstrap.session, &app_state);

--- a/zig/src/coding_agent/interactive_mode/chat_rendering.zig
+++ b/zig/src/coding_agent/interactive_mode/chat_rendering.zig
@@ -217,7 +217,7 @@ pub fn previewThreshold(kind: ChatKind) ?usize {
     return switch (kind) {
         .thinking => 1,
         .tool_result => 3,
-        .assistant, .markdown => 5,
+        .assistant, .markdown => null,
         .welcome, .info, .@"error", .user, .tool_call, .bash_execution => null,
     };
 }

--- a/zig/src/coding_agent/interactive_mode/input_dispatch.zig
+++ b/zig/src/coding_agent/interactive_mode/input_dispatch.zig
@@ -742,6 +742,7 @@ pub fn submitEditorText(
 
     try prompt_worker.start(allocator, session, app_state, expanded, prompt_images);
     prompt_worker_active.* = true;
+    app_state.setToolOutputExpanded(false);
     try editor.addToHistory(trimmed);
     clearEditor(app_state, editor);
     try app_state.setStatus("thinking");

--- a/zig/src/coding_agent/interactive_mode/input_dispatch.zig
+++ b/zig/src/coding_agent/interactive_mode/input_dispatch.zig
@@ -1108,6 +1108,12 @@ pub fn freeOwnedSelectItems(allocator: std.mem.Allocator, items: []tui.SelectIte
 }
 
 pub fn pollForInput() !bool {
+    if (@import("builtin").os.tag == .windows) {
+        const stdin_handle = std.Io.File.stdin().handle;
+        const timeout: std.os.windows.LARGE_INTEGER = -@as(i64, 50) * 10000; // 50ms
+        const status = std.os.windows.ntdll.NtWaitForSingleObject(stdin_handle, .FALSE, &timeout);
+        return status == .SUCCESS;
+    }
     var fds = [_]std.posix.pollfd{
         .{
             .fd = 0,

--- a/zig/src/coding_agent/interactive_mode/session_overlay.zig
+++ b/zig/src/coding_agent/interactive_mode/session_overlay.zig
@@ -410,6 +410,9 @@ fn pathsEqualCanonical(allocator: std.mem.Allocator, lhs: []const u8, rhs: []con
 }
 
 fn realpathAllocOrNull(allocator: std.mem.Allocator, path: []const u8) ?[]u8 {
+    if (@import("builtin").os.tag == .windows) {
+        return std.fs.path.resolve(allocator, &.{path}) catch return null;
+    }
     const z_path = allocator.dupeZ(u8, path) catch return null;
     defer allocator.free(z_path);
     var buffer: [std.Io.Dir.max_path_bytes]u8 = undefined;

--- a/zig/src/coding_agent/modes/mcp_stdio.zig
+++ b/zig/src/coding_agent/modes/mcp_stdio.zig
@@ -401,7 +401,7 @@ pub const StdioClient = struct {
             .stdin = .pipe,
             .stdout = .pipe,
             .stderr = .ignore,
-            .pgid = 0,
+            .pgid = null,
         });
         errdefer if (child.id != null) child.kill(io);
 
@@ -463,8 +463,12 @@ pub const StdioClient = struct {
 
     fn killProcessGroup(self: *StdioClient) void {
         if (self.child.id) |pid| {
-            std.posix.kill(-pid, .TERM) catch {};
-            std.posix.kill(-pid, .KILL) catch {};
+            if (@import("builtin").os.tag == .windows) {
+                _ = std.os.windows.ntdll.NtTerminateProcess(pid, @enumFromInt(@as(u32, 1)));
+            } else {
+                std.posix.kill(-pid, .TERM) catch {};
+                std.posix.kill(-pid, .KILL) catch {};
+            }
         }
     }
 
@@ -476,6 +480,38 @@ pub const StdioClient = struct {
 
     fn recvMessage(self: *StdioClient, allocator: std.mem.Allocator) ![]u8 {
         const file = self.stdout_file orelse return ProtocolError.McpTransportEof;
+
+        if (@import("builtin").os.tag == .windows) {
+            // Windows: use WaitForSingleObject for timeout + File reader for I/O
+            var line = std.ArrayList(u8).empty;
+            defer line.deinit(allocator);
+            var elapsed: u64 = 0;
+            while (elapsed <= self.response_timeout_ms) : (elapsed += 10) {
+                // Check if data is available
+                const timeout_us: std.os.windows.LARGE_INTEGER = -@as(i64, 10) * 10000; // 10ms
+                _ = std.os.windows.ntdll.NtWaitForSingleObject(file.handle, .FALSE, &timeout_us);
+
+                if (self.wait_done.load(.seq_cst)) return if (line.items.len == 0) ProtocolError.McpChildExited else ProtocolError.McpTransportEof;
+
+                var buffer: [1024]u8 = undefined;
+                var reader = file.reader(self.io, &buffer);
+                const bytes_read = reader.interface.readSliceShort(&buffer) catch |err| return err;
+                if (bytes_read == 0) {
+                    std.Io.sleep(self.io, .fromMilliseconds(10), .awake) catch {};
+                    continue;
+                }
+                if (std.mem.indexOfScalar(u8, buffer[0..bytes_read], '\n')) |newline_index| {
+                    try line.appendSlice(allocator, buffer[0..newline_index]);
+                    const raw = line.items;
+                    const trimmed = if (raw.len > 0 and raw[raw.len - 1] == '\r') raw[0 .. raw.len - 1] else raw;
+                    return try allocator.dupe(u8, trimmed);
+                }
+                try line.appendSlice(allocator, buffer[0..bytes_read]);
+            }
+            return ProtocolError.McpTransportTimeout;
+        }
+
+        // POSIX: use fcntl for non-blocking I/O
         const fd = file.handle;
         const previous_flags = std.c.fcntl(fd, std.c.F.GETFL, @as(c_int, 0));
         if (previous_flags == -1) return ProtocolError.McpTransportEof;

--- a/zig/src/coding_agent/modes/print_mode.zig
+++ b/zig/src/coding_agent/modes/print_mode.zig
@@ -21,13 +21,19 @@ pub const RunPrintModeOptions = struct {
     messages: []const []const u8 = &.{},
 };
 
-const SignalGuard = struct {
+const SignalGuard = if (builtin.os.tag == .windows) struct {
+    installed: bool = false,
+
+    fn install(_: *std.atomic.Value(bool)) SignalGuard {
+        return .{};
+    }
+
+    fn deinit(_: *SignalGuard) void {}
+} else struct {
     previous_sigint: ?std.posix.Sigaction = null,
     installed: bool = false,
 
     fn install(signal: *std.atomic.Value(bool)) SignalGuard {
-        if (comptime builtin.os.tag == .windows) return .{};
-
         active_abort_signal = signal;
         const action: std.posix.Sigaction = .{
             .handler = .{ .sigaction = handleSigint },
@@ -44,7 +50,7 @@ const SignalGuard = struct {
     }
 
     fn deinit(self: *SignalGuard) void {
-        if (!self.installed or !supportsPosixSignals()) return;
+        if (!self.installed) return;
         if (self.previous_sigint) |previous| {
             std.posix.sigaction(.INT, &previous, null);
         }
@@ -60,15 +66,7 @@ const SignalGuard = struct {
 /// performs the actual abort outside signal-handler context.
 var active_abort_signal: ?*std.atomic.Value(bool) = null;
 
-fn supportsPosixSignals() bool {
-    return switch (builtin.os.tag) {
-        .windows, .wasi, .emscripten, .freestanding => false,
-        else => true,
-    };
-}
-
 fn handleSigint(sig: std.posix.SIG, info: *const std.posix.siginfo_t, ctx_ptr: ?*anyopaque) callconv(.c) void {
-    if (comptime builtin.os.tag == .windows) return;
     _ = info;
     _ = ctx_ptr;
     if (sig != .INT) return;

--- a/zig/src/coding_agent/modes/print_mode.zig
+++ b/zig/src/coding_agent/modes/print_mode.zig
@@ -26,7 +26,7 @@ const SignalGuard = struct {
     installed: bool = false,
 
     fn install(signal: *std.atomic.Value(bool)) SignalGuard {
-        if (!supportsPosixSignals()) return .{};
+        if (comptime builtin.os.tag == .windows) return .{};
 
         active_abort_signal = signal;
         const action: std.posix.Sigaction = .{
@@ -68,6 +68,7 @@ fn supportsPosixSignals() bool {
 }
 
 fn handleSigint(sig: std.posix.SIG, info: *const std.posix.siginfo_t, ctx_ptr: ?*anyopaque) callconv(.c) void {
+    if (comptime builtin.os.tag == .windows) return;
     _ = info;
     _ = ctx_ptr;
     if (sig != .INT) return;

--- a/zig/src/coding_agent/modes/ts_rpc_bash.zig
+++ b/zig/src/coding_agent/modes/ts_rpc_bash.zig
@@ -589,7 +589,8 @@ fn waitDirectBashChild(state: *BashWaitState) void {
 fn readDirectBashOutput(state: *BashOutputReaderState) void {
     var buffer: [4096]u8 = undefined;
     while (true) {
-        const bytes_read = std.posix.read(state.file.handle, &buffer) catch |err| {
+        var reader = state.file.reader(state.io, &buffer);
+        const bytes_read = reader.interface.readSliceShort(&buffer) catch |err| {
             state.err = err;
             return;
         };
@@ -601,9 +602,13 @@ fn readDirectBashOutput(state: *BashOutputReaderState) void {
     }
 }
 
-fn killDirectBashProcessGroup(pid: std.posix.pid_t) void {
-    std.posix.kill(-pid, .TERM) catch {};
-    std.posix.kill(-pid, .KILL) catch {};
+fn killDirectBashProcessGroup(pid: std.process.Child.Id) void {
+    if (@import("builtin").os.tag == .windows) {
+        _ = std.os.windows.ntdll.NtTerminateProcess(pid, @enumFromInt(@as(u32, 1)));
+    } else {
+        std.posix.kill(-pid, .TERM) catch {};
+        std.posix.kill(-pid, .KILL) catch {};
+    }
 }
 
 pub fn runDirectBash(
@@ -625,16 +630,29 @@ pub fn runDirectBash(
     };
     defer cwd_dir.close(io);
 
-    const wrapped_command = try std.fmt.allocPrint(allocator, "exec 2>&1\n{s}", .{command});
-    defer allocator.free(wrapped_command);
-    const argv = [_][]const u8{ "/bin/sh", "-c", wrapped_command };
+    const builtin = @import("builtin");
+    var argv_buf: [3][]const u8 = undefined;
+    var argv_len: usize = 0;
+    if (builtin.os.tag == .windows) {
+        argv_buf[0] = "bash";
+        argv_buf[1] = "-c";
+        argv_buf[2] = try std.fmt.allocPrint(allocator, "exec 2>&1\n{s}", .{command});
+        argv_len = 3;
+    } else {
+        argv_buf[0] = "/bin/sh";
+        argv_buf[1] = "-c";
+        argv_buf[2] = try std.fmt.allocPrint(allocator, "exec 2>&1\n{s}", .{command});
+        argv_len = 3;
+    }
+    const argv = argv_buf[0..argv_len];
+    defer allocator.free(argv[2]);
     var child = try std.process.spawn(io, .{
-        .argv = argv[0..],
+        .argv = argv,
         .cwd = .{ .path = cwd },
         .stdin = .ignore,
         .stdout = .pipe,
         .stderr = .ignore,
-        .pgid = 0,
+        .pgid = null,
     });
     defer {
         if (child.id != null) child.kill(io);

--- a/zig/src/coding_agent/modes/ts_rpc_mode.zig
+++ b/zig/src/coding_agent/modes/ts_rpc_mode.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const ai = @import("ai");
 const agent = @import("agent");
 const ts_rpc_wire = @import("ts_rpc_wire.zig");
@@ -2302,14 +2303,21 @@ pub fn runTsRpcMode(
 }
 
 fn pollTsRpcStdin(timeout_ms: i32) !bool {
-    var fds = [_]std.posix.pollfd{
-        .{
-            .fd = 0,
-            .events = std.posix.POLL.IN,
-            .revents = 0,
-        },
-    };
-    return (try std.posix.poll(fds[0..], timeout_ms)) > 0;
+    if (builtin.os.tag == .windows) {
+        const stdin_handle = std.Io.File.stdin().handle;
+        const timeout: std.os.windows.LARGE_INTEGER = -@as(i64, @intCast(timeout_ms)) * 10000;
+        const status = std.os.windows.ntdll.NtWaitForSingleObject(stdin_handle, .FALSE, &timeout);
+        return status == .SUCCESS;
+    } else {
+        var fds = [_]std.posix.pollfd{
+            .{
+                .fd = 0,
+                .events = std.posix.POLL.IN,
+                .revents = 0,
+            },
+        };
+        return (try std.posix.poll(fds[0..], timeout_ms)) > 0;
+    }
 }
 
 fn handleTsRpcAgentEvent(context: ?*anyopaque, event: agent.AgentEvent) !void {

--- a/zig/src/coding_agent/packages/package_manager.zig
+++ b/zig/src/coding_agent/packages/package_manager.zig
@@ -2191,6 +2191,9 @@ fn packageSourceFromItem(allocator: std.mem.Allocator, item: std.json.Value) ![]
 }
 
 fn realpathOrResolved(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
+    if (@import("builtin").os.tag == .windows) {
+        return std.fs.path.resolve(allocator, &.{path}) catch allocator.dupe(u8, path);
+    }
     const z_path = try allocator.dupeZ(u8, path);
     defer allocator.free(z_path);
     var buffer: [std.Io.Dir.max_path_bytes]u8 = undefined;

--- a/zig/src/coding_agent/tools/bash.zig
+++ b/zig/src/coding_agent/tools/bash.zig
@@ -165,17 +165,29 @@ pub const BashTool = struct {
         };
         defer cwd_dir.close(self.io);
 
-        const wrapped_command = try std.fmt.allocPrint(allocator, "exec 2>&1\n{s}", .{args.command});
-        defer allocator.free(wrapped_command);
-
-        const argv = [_][]const u8{ "/bin/sh", "-c", wrapped_command };
+        const builtin = @import("builtin");
+        var argv_buf: [3][]const u8 = undefined;
+        var argv_len: usize = 0;
+        if (builtin.os.tag == .windows) {
+            argv_buf[0] = "bash";
+            argv_buf[1] = "-c";
+            argv_buf[2] = try std.fmt.allocPrint(allocator, "exec 2>&1\n{s}", .{args.command});
+            argv_len = 3;
+        } else {
+            argv_buf[0] = "/bin/sh";
+            argv_buf[1] = "-c";
+            argv_buf[2] = try std.fmt.allocPrint(allocator, "exec 2>&1\n{s}", .{args.command});
+            argv_len = 3;
+        }
+        const argv = argv_buf[0..argv_len];
+        defer allocator.free(argv[2]);
         var child = try std.process.spawn(self.io, .{
             .argv = argv[0..],
             .cwd = .{ .path = self.cwd },
             .stdin = .ignore,
             .stdout = .pipe,
             .stderr = .ignore,
-            .pgid = 0,
+            .pgid = null,
         });
         defer {
             if (child.id != null) child.kill(self.io);
@@ -422,7 +434,8 @@ const WaitState = struct {
 fn readOutputThread(state: *OutputReaderState) void {
     var buffer: [4096]u8 = undefined;
     while (true) {
-        const bytes_read = std.posix.read(state.file.handle, &buffer) catch |err| {
+        var reader = state.file.reader(state.io, &buffer);
+        const bytes_read = reader.interface.readSliceShort(&buffer) catch |err| {
             state.err = err;
             return;
         };
@@ -443,9 +456,13 @@ fn waitChildThread(state: *WaitState) void {
     state.done.store(true, .seq_cst);
 }
 
-fn killProcessGroup(pid: std.posix.pid_t) void {
-    std.posix.kill(-pid, .TERM) catch {};
-    std.posix.kill(-pid, .KILL) catch {};
+fn killProcessGroup(pid: std.process.Child.Id) void {
+    if (@import("builtin").os.tag == .windows) {
+        _ = std.os.windows.ntdll.NtTerminateProcess(pid, @enumFromInt(@as(u32, 1)));
+    } else {
+        std.posix.kill(-pid, .TERM) catch {};
+        std.posix.kill(-pid, .KILL) catch {};
+    }
 }
 
 fn exitCodeFromTerm(term: std.process.Child.Term) ?u8 {

--- a/zig/src/main.zig
+++ b/zig/src/main.zig
@@ -35,7 +35,8 @@ pub fn main(init: std.process.Init) !void {
 
     var argv = std.ArrayList([]const u8).empty;
     defer argv.deinit(init.gpa);
-    var it = init.minimal.args.iterate();
+    var it = try std.process.Args.Iterator.initAllocator(init.minimal.args, init.gpa);
+    defer it.deinit();
     _ = it.next();
     while (it.next()) |arg| {
         try argv.append(init.gpa, arg);

--- a/zig/src/tui/terminal.zig
+++ b/zig/src/tui/terminal.zig
@@ -218,7 +218,11 @@ pub const Terminal = struct {
                 self.current_size = try backend.getSize();
             },
             .native => |*native| {
-                if (native.resize_pending.swap(false, .seq_cst)) {
+                // On Windows, SIGWINCH is unavailable, so always poll the size.
+                // On POSIX, only re-read when the signal fires.
+                const should_read = builtin.os.tag == .windows or
+                    native.resize_pending.swap(false, .seq_cst);
+                if (should_read) {
                     self.current_size = native.readSize(self.current_size);
                 }
             },

--- a/zig/vendor/vaxis/src/Loop.zig
+++ b/zig/vendor/vaxis/src/Loop.zig
@@ -187,10 +187,8 @@ pub fn Loop(comptime T: type) type {
                                     if (raw_debug_path) |path| {
                                         writeRawInputDebugParseError(self.io, path, buf[seq_start], err) catch {};
                                     }
-                                    log.warn("failed to parse tty input byte 0x{x}: {s}", .{
-                                        buf[seq_start],
-                                        @errorName(err),
-                                    });
+                                    // Silently skip unparseable input bytes to avoid
+                                    // corrupting the TUI with stderr output.
                                     seq_start += 1;
                                     read_start = 0;
                                     continue;

--- a/zig/vendor/vaxis/src/Parser.zig
+++ b/zig/vendor/vaxis/src/Parser.zig
@@ -175,7 +175,7 @@ inline fn parseSs3(input: []const u8) Result {
         'R' => .{ .codepoint = Key.f3 },
         'S' => .{ .codepoint = Key.f4 },
         else => {
-            log.warn("unhandled ss3: {x}", .{input[2]});
+            // Silently ignore unhandled SS3 sequences to avoid TUI corruption.
             return .{
                 .event = null,
                 .n = 3,

--- a/zig/vendor/vaxis/src/tty.zig
+++ b/zig/vendor/vaxis/src/tty.zig
@@ -484,8 +484,6 @@ pub const WindowsTty = struct {
                     0xdd => ']',
                     0xde => '\'',
                     else => {
-                        const log = std.log.scoped(.vaxis);
-                        log.warn("unknown wVirtualKeyCode: 0x{x}", .{event.wVirtualKeyCode});
                         return null;
                     },
                 };
@@ -587,7 +585,6 @@ pub const WindowsTty = struct {
                         break :blk .button_9;
                     },
                     else => {
-                        std.log.warn("unknown mouse event: {}", .{event});
                         return null;
                     },
                 };


### PR DESCRIPTION
## Summary
- Add Windows platform compatibility across 12 source files
- Fix TUI corruption from vaxis stderr warnings on Windows
- Fix terminal resize detection on Windows (poll getWinsize since SIGWINCH unavailable)
- Fix assistant message output truncation (remove 5-row collapse threshold)
- Auto-expand tool output when agent completes a turn
- Fix Windows build error (POSIX sigaction symbol leaking)
- Add Windows to Zig CI matrix

## Test plan
- [ ] Verify build succeeds on Windows with `zig build`
- [ ] Verify build still works on Linux/macOS
- [ ] Test terminal resize on Windows
- [ ] Test voice input / special key combinations don't corrupt TUI
- [ ] Test assistant messages display fully