### PR TITLE
fix(zig): resolve Windows build errors for ReleaseFast

### DIFF
--- a/zig/src/coding_agent/extensions/extension_host.zig
+++ b/zig/src/coding_agent/extensions/extension_host.zig
@@ -769,9 +769,12 @@ fn stderrMain(host: *HostProcess) void {
     var buffer: [4096]u8 = undefined;
     while (true) {
         const file = host.stderr_file orelse break;
-        const bytes_read = std.posix.read(file.handle, &buffer) catch |err| {
-            host.stderr_err = err;
-            break;
+        const bytes_read = file.readStreaming(host.io, &.{&buffer}) catch |err| switch (err) {
+            error.EndOfStream => break,
+            else => {
+                host.stderr_err = err;
+                break;
+            },
         };
         if (bytes_read == 0) break;
         for (buffer[0..bytes_read]) |byte| {

--- a/zig/src/coding_agent/packages/package_manager.zig
+++ b/zig/src/coding_agent/packages/package_manager.zig
@@ -655,6 +655,9 @@ fn extensionProvenanceLockfilePath(
 }
 
 fn realpathAlloc(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
+    if (@import("builtin").os.tag == .windows) {
+        return std.fs.path.resolve(allocator, &.{path}) catch allocator.dupe(u8, path);
+    }
     const z_path = try allocator.dupeZ(u8, path);
     defer allocator.free(z_path);
     var buffer: [std.Io.Dir.max_path_bytes]u8 = undefined;

--- a/zig/src/coding_agent/resources/resources.zig
+++ b/zig/src/coding_agent/resources/resources.zig
@@ -1463,6 +1463,9 @@ fn provenanceEntryKeyForSource(allocator: std.mem.Allocator, source: []const u8,
 }
 
 fn realpathAlloc(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
+    if (@import("builtin").os.tag == .windows) {
+        return std.fs.path.resolve(allocator, &.{path}) catch allocator.dupe(u8, path);
+    }
     const z_path = try allocator.dupeZ(u8, path);
     defer allocator.free(z_path);
     var buffer: [std.Io.Dir.max_path_bytes]u8 = undefined;


### PR DESCRIPTION
- Replace std.posix.read with file.readStreaming in extension_host.zig stderrMain (std.posix is unavailable on Windows)
- Add Windows branch to realpathAlloc in package_manager.zig and resources.zig using std.fs.path.resolve instead of std.c.realpath