### PR TITLE
feat(tui): scroll-to-bottom indicator + fix Windows path normalization

### DIFF
--- a/zig/src/coding_agent/interactive_mode/chat_rendering.zig
+++ b/zig/src/coding_agent/interactive_mode/chat_rendering.zig
@@ -592,7 +592,7 @@ fn extractSelectedTextFromItems(
         item_row += entry_rows;
     }
 
-    extractSelectedText(allocator, &scratch, 0, visible_height, selection, output);
+    try extractSelectedText(allocator, &scratch, 0, visible_height, selection, output);
 }
 
 fn isCellSelected(row: usize, col: usize, sel: SelectionRange) bool {

--- a/zig/src/coding_agent/interactive_mode/chat_rendering.zig
+++ b/zig/src/coding_agent/interactive_mode/chat_rendering.zig
@@ -20,6 +20,13 @@ const ItemLayout = struct {
     rows: usize,
 };
 
+pub const SelectionRange = struct {
+    start_row: usize,
+    start_col: usize,
+    end_row: usize,
+    end_col: usize,
+};
+
 /// Renders chat items into `window`, applying scroll offset without allocating
 /// a full-size scratch screen. Only items that overlap the visible area are
 /// rendered, avoiding expensive off-screen markdown processing.
@@ -34,6 +41,8 @@ pub fn drawViewport(
     chat_scroll_offset: usize,
     now_ms: i64,
     all_expanded: bool,
+    selection: ?SelectionRange,
+    selected_text_out: ?*std.ArrayList(u8),
 ) !ViewportMetrics {
     if (start_row >= window.height or height == 0) return .{ .rendered_height = 0, .visible_height = 0 };
 
@@ -76,10 +85,22 @@ pub fn drawViewport(
                 dst, allocator, keybindings, theme,
                 items[item_index], dst_row, slice_height,
                 draw_start, now_ms, all_expanded, width,
+                selection, src_start,
             );
             dst_row += slice_height;
         }
         item_row += entry_rows;
+    }
+
+    // Extract selected text by re-rendering visible items into a scratch screen.
+    if (selected_text_out) |text_out| {
+        if (selection) |sel| {
+            try extractSelectedTextFromItems(
+                allocator, keybindings, theme,
+                items, layout, src_start, visible_height, width,
+                now_ms, all_expanded, sel, text_out,
+            );
+        }
     }
 
     drawScrollIndicators(dst, theme, src_start, rendered_height, visible_height);
@@ -121,6 +142,8 @@ fn renderItemSlice(
     now_ms: i64,
     all_expanded: bool,
     width: usize,
+    selection: ?SelectionRange,
+    viewport_src_start: usize,
 ) !void {
     // Allocate a small scratch screen just for this item.
     const full_height = estimateItemRowsFull(item, width, true);
@@ -142,7 +165,11 @@ fn renderItemSlice(
         .height = @intCast(slice_height),
     });
     const actual_src = @min(src_skip, @as(usize, scratch.height) -| 1);
-    blitScreenRows(&scratch, child, actual_src, slice_height);
+    if (selection) |sel| {
+        blitScreenRowsWithSelection(&scratch, child, actual_src, slice_height, sel, viewport_src_start + dst_row - actual_src);
+    } else {
+        blitScreenRows(&scratch, child, actual_src, slice_height);
+    }
 }
 
 fn drawScrollIndicators(
@@ -458,6 +485,153 @@ fn normalizeCellForBlit(cell: tui.vaxis.Cell) tui.vaxis.Cell {
     var normalized = cell;
     normalized.char = .{ .grapheme = " ", .width = 1 };
     return normalized;
+}
+
+fn blitScreenRowsWithSelection(
+    source: *tui.vaxis.Screen,
+    dest: tui.vaxis.Window,
+    source_start_row: usize,
+    height: usize,
+    selection: SelectionRange,
+    dest_abs_row_start: usize,
+) void {
+    const rows = @min(height, @as(usize, dest.height));
+    const cols = @min(@as(usize, source.width), @as(usize, dest.width));
+    for (0..rows) |row| {
+        const abs_row = source_start_row + row;
+        for (0..cols) |col| {
+            var cell = source.readCell(@intCast(col), @intCast(abs_row)) orelse continue;
+            cell = normalizeCellForBlit(cell);
+            const dest_abs_row = dest_abs_row_start + row;
+            if (isCellSelected(dest_abs_row, col, selection)) {
+                const fg = cell.style.fg;
+                cell.style.fg = switch (cell.style.bg) {
+                    .default => .{ .rgb = .{ 200, 200, 200 } },
+                    else => cell.style.bg,
+                };
+                cell.style.bg = switch (fg) {
+                    .default => .{ .rgb = .{ 50, 50, 50 } },
+                    else => fg,
+                };
+            }
+            dest.writeCell(@intCast(col), @intCast(row), cell);
+        }
+    }
+}
+
+fn extractSelectedTextFromItems(
+    allocator: std.mem.Allocator,
+    keybindings: ?*const keybindings_mod.Keybindings,
+    theme: ?*const resources_mod.Theme,
+    items: []const ChatItem,
+    layout: Layout,
+    src_start: usize,
+    visible_height: usize,
+    width: usize,
+    now_ms: i64,
+    all_expanded: bool,
+    selection: SelectionRange,
+    output: *std.ArrayList(u8),
+) !void {
+    // Find items overlapping the visible area.
+    var item_row: usize = 0;
+    var item_index: usize = 0;
+    while (item_index < layout.entries.items.len) : (item_index += 1) {
+        const entry_rows = layout.entries.items[item_index].rows;
+        const item_end = item_row + entry_rows;
+        if (item_end > src_start) break;
+        item_row = item_end;
+    }
+
+    // Re-render visible items into a full scratch screen for text extraction.
+    var scratch = try tui.vaxis.Screen.init(allocator, .{
+        .rows = @intCast(@min(visible_height, @as(usize, std.math.maxInt(u16)))),
+        .cols = @intCast(@min(width, @as(usize, std.math.maxInt(u16)))),
+        .x_pixel = 0,
+        .y_pixel = 0,
+    });
+    defer scratch.deinit(allocator);
+
+    const scratch_window = tui.draw.rootWindow(&scratch);
+    scratch_window.clear();
+
+    var dst_row: usize = 0;
+    while (item_index < items.len and dst_row < visible_height) : (item_index += 1) {
+        const entry_rows = if (item_index < layout.entries.items.len) layout.entries.items[item_index].rows else estimateItemRowsVisible(items[item_index], width, all_expanded);
+        const draw_start = if (item_row < src_start) src_start - item_row else 0;
+        const available = visible_height - dst_row;
+
+        if (draw_start < entry_rows and available > 0) {
+            const slice_height = @min(entry_rows - draw_start, available);
+            // Render item into its own small scratch screen.
+            const item_scratch_rows = @max(@as(usize, 1), @min(entry_rows, draw_start + slice_height + 1));
+            var item_scratch = try tui.vaxis.Screen.init(allocator, .{
+                .rows = @intCast(@min(item_scratch_rows, @as(usize, std.math.maxInt(u16)))),
+                .cols = @intCast(width),
+                .x_pixel = 0,
+                .y_pixel = 0,
+            });
+            defer item_scratch.deinit(allocator);
+
+            const item_window = tui.draw.rootWindow(&item_scratch);
+            item_window.clear();
+            _ = try drawItem(item_window, allocator, keybindings, theme, items[item_index], 0, now_ms, all_expanded);
+
+            // Blit the item's rendered rows into the scratch screen at the correct position.
+            const actual_src = @min(draw_start, @as(usize, item_scratch.height) -| 1);
+            const rows_to_copy = @min(slice_height, visible_height - dst_row);
+            const cols = @min(@as(usize, item_scratch.width), @as(usize, scratch.width));
+            for (0..rows_to_copy) |r| {
+                for (0..cols) |c| {
+                    const cell = item_scratch.readCell(@intCast(c), @intCast(actual_src + r)) orelse continue;
+                    scratch_window.writeCell(@intCast(c), @intCast(dst_row + r), normalizeCellForBlit(cell));
+                }
+            }
+            dst_row += slice_height;
+        }
+        item_row += entry_rows;
+    }
+
+    extractSelectedText(allocator, &scratch, 0, visible_height, selection, output);
+}
+
+fn isCellSelected(row: usize, col: usize, sel: SelectionRange) bool {
+    if (row < sel.start_row or row > sel.end_row) return false;
+    if (row == sel.start_row and row == sel.end_row) return col >= sel.start_col and col < sel.end_col;
+    if (row == sel.start_row) return col >= sel.start_col;
+    if (row == sel.end_row) return col < sel.end_col;
+    return true;
+}
+
+fn extractSelectedText(
+    allocator: std.mem.Allocator,
+    source: *tui.vaxis.Screen,
+    source_start_row: usize,
+    visible_height: usize,
+    selection: SelectionRange,
+    output: *std.ArrayList(u8),
+) !void {
+    const cols = source.width;
+    const rows = @min(visible_height, @as(usize, source.height));
+    for (0..rows) |row| {
+        const abs_row = source_start_row + row;
+        if (abs_row < selection.start_row or abs_row > selection.end_row) continue;
+        const col_start: usize = if (abs_row == selection.start_row) selection.start_col else 0;
+        const col_end: usize = if (abs_row == selection.end_row) @min(selection.end_col, @as(usize, cols)) else @as(usize, cols);
+        var trailing_space: usize = 0;
+        for (col_start..col_end) |col| {
+            const cell = source.readCell(@intCast(col), @intCast(abs_row)) orelse continue;
+            const grapheme = cell.char.grapheme;
+            if (grapheme.len == 0 or (grapheme.len == 1 and grapheme[0] == ' ')) {
+                trailing_space += 1;
+            } else {
+                for (0..trailing_space) |_| try output.append(allocator, ' ');
+                trailing_space = 0;
+                try output.appendSlice(allocator, grapheme);
+            }
+        }
+        if (abs_row < selection.end_row) try output.append(allocator, '\n');
+    }
 }
 
 fn drawWrappedText(

--- a/zig/src/coding_agent/interactive_mode/input_dispatch.zig
+++ b/zig/src/coding_agent/interactive_mode/input_dispatch.zig
@@ -1200,6 +1200,11 @@ pub fn dispatchInputEvent(
                 context.app_state.handleChatMouseWheel(wheel);
             }
         },
+        .mouse_click => |click| {
+            if (context.overlay.* == null and context.auth_flow.* == null) {
+                context.app_state.handleMouseClick(click);
+            }
+        },
     }
     consumeInputBytes(input_buffer, parsed.consumed);
 }
@@ -1287,6 +1292,7 @@ fn dispatchMainEditorShortcut(
             context.app_state,
             context.editor,
         ),
+        .chat_scrollToBottom => context.app_state.chatScrollToBottom(),
         else => return false,
     }
 
@@ -2078,6 +2084,7 @@ pub fn handleAppAction(
         // Clipboard image paste is handled before the app dispatcher because it
         // depends only on environment/clipboard state, not session execution state.
         .clipboard_pasteImage => {},
+        .chat_scrollToBottom => app_state.chatScrollToBottom(),
         // Overlay-scoped actions are resolved and executed only by their overlay
         // dispatchers. Listing each action here makes new Action variants require
         // deliberate main-editor dispatch coverage at compile time.

--- a/zig/src/coding_agent/interactive_mode/input_dispatch.zig
+++ b/zig/src/coding_agent/interactive_mode/input_dispatch.zig
@@ -1205,6 +1205,16 @@ pub fn dispatchInputEvent(
                 context.app_state.handleMouseClick(click);
             }
         },
+        .mouse_drag => |drag| {
+            if (context.overlay.* == null and context.auth_flow.* == null) {
+                context.app_state.handleMouseDrag(drag);
+            }
+        },
+        .mouse_release => |release| {
+            if (context.overlay.* == null and context.auth_flow.* == null) {
+                context.app_state.handleMouseRelease(release);
+            }
+        },
     }
     consumeInputBytes(input_buffer, parsed.consumed);
 }

--- a/zig/src/coding_agent/interactive_mode/rendering.zig
+++ b/zig/src/coding_agent/interactive_mode/rendering.zig
@@ -2287,10 +2287,11 @@ pub const ScreenComponent = struct {
             self.now_ms,
             snapshot.all_expanded,
             sel_range,
-            if (self.state.selection_active) &selected_text else null,
+            if (self.state.hasSelection()) &selected_text else null,
         );
-        if (!self.state.selection_active and selected_text.items.len > 0) {
+        if (!self.state.selection_active and self.state.hasSelection() and selected_text.items.len > 0) {
             copySelectedText(ctx.arena, self.state.io, selected_text.items);
+            self.state.clearSelection();
         }
         self.state.updateChatScrollLayout(chat_metrics.rendered_height, chat_metrics.visible_height, row, width);
         row += chat_capacity;

--- a/zig/src/coding_agent/interactive_mode/rendering.zig
+++ b/zig/src/coding_agent/interactive_mode/rendering.zig
@@ -169,6 +169,7 @@ pub const AppState = struct {
     chat_visible_rows: usize = 0,
     chat_width: usize = 1,
     chat_region: ChatRegion = .{},
+    scroll_indicator_row: ?usize = null,
     all_expanded: bool = false,
     last_streaming_assistant_index: ?usize = null,
     last_streaming_thinking_index: ?usize = null,
@@ -528,6 +529,22 @@ pub const AppState = struct {
         self.mutex.lockUncancelable(self.io);
         defer self.mutex.unlock(self.io);
         self.chat_scroll_offset = self.chat_scroll_offset -| self.chatScrollPageSizeLocked();
+    }
+
+    pub fn chatScrollToBottom(self: *AppState) void {
+        self.mutex.lockUncancelable(self.io);
+        defer self.mutex.unlock(self.io);
+        self.chat_scroll_offset = 0;
+    }
+
+    pub fn handleMouseClick(self: *AppState, click: tui.keys.MouseClickInput) void {
+        self.mutex.lockUncancelable(self.io);
+        defer self.mutex.unlock(self.io);
+        if (self.scroll_indicator_row) |indicator_row| {
+            if (click.row == @as(i16, @intCast(indicator_row))) {
+                self.chat_scroll_offset = 0;
+            }
+        }
     }
 
     fn chatScrollPageSizeLocked(self: *const AppState) usize {
@@ -2131,7 +2148,8 @@ pub const ScreenComponent = struct {
         const queued_height = try measureQueuedMessagesHeight(ctx.arena, self.keybindings, self.theme, &snapshot, width);
         const autocomplete_height = try measureAutocompleteHeight(ctx.arena, self.theme, self.editor, width);
         const task_panel_height = taskPanelHeightForWidth(width);
-        const reserved_lines: usize = task_panel_height + prompt_height + queued_height + 1 + autocomplete_height;
+        const scroll_indicator_height: usize = if (snapshot.chat_scroll_offset > 0) 1 else 0;
+        const reserved_lines: usize = task_panel_height + prompt_height + queued_height + 1 + autocomplete_height + scroll_indicator_height;
         const window_height: usize = @max(@as(usize, window.height), 1);
         const chat_capacity = if (window_height > reserved_lines) window_height - reserved_lines else 1;
 
@@ -2163,6 +2181,29 @@ pub const ScreenComponent = struct {
         );
         self.state.updateChatScrollLayout(chat_metrics.rendered_height, chat_metrics.visible_height, row, width);
         row += chat_capacity;
+
+        if (snapshot.chat_scroll_offset > 0 and row < window.height) {
+            self.state.scroll_indicator_row = row;
+            const indicator_text = " \xe2\x86\x91 scrolled  \xe2\x86\x93 Jump to bottom (Ctrl+End) ";
+            const indicator_style = styleForToken(self.theme, .status);
+            const indicator_window = window.child(.{
+                .y_off = @intCast(row),
+                .height = 1,
+            });
+            indicator_window.fill(.{
+                .char = .{ .grapheme = " ", .width = 1 },
+                .style = indicator_style,
+            });
+            const text_width = std.unicode.utf8CountCodepoints(indicator_text) catch indicator_text.len;
+            const x_center: usize = if (width > text_width) (width - text_width) / 2 else 0;
+            _ = indicator_window.printSegment(.{
+                .text = indicator_text,
+                .style = indicator_style,
+            }, .{ .col_offset = @intCast(x_center), .wrap = .none });
+            row += 1;
+        } else {
+            self.state.scroll_indicator_row = null;
+        }
 
         if (queued_height > 0 and row < window.height) {
             const queued_window = window.child(.{

--- a/zig/src/coding_agent/interactive_mode/rendering.zig
+++ b/zig/src/coding_agent/interactive_mode/rendering.zig
@@ -24,6 +24,7 @@ const overlay_panel = @import("overlay_panel.zig");
 const pending_editor_images_mod = @import("pending_editor_images.zig");
 const prompt_rendering = @import("prompt_rendering.zig");
 const render_text = @import("render_text.zig");
+const slash_commands = @import("slash_commands.zig");
 const currentSessionLabel = shared.currentSessionLabel;
 const SelectorOverlay = overlays.SelectorOverlay;
 const ASSISTANT_PREFIX = formatting.ASSISTANT_PREFIX;
@@ -55,6 +56,13 @@ pub const FooterUsageTotals = struct {
 pub const ExtensionWidgetPlacement = extension_ui.WidgetPlacement;
 pub const ExtensionWidget = extension_ui.Widget;
 pub const EXTENSION_WIDGET_TRUNCATION_MARKER = extension_ui.WIDGET_TRUNCATION_MARKER;
+
+pub const SelectionRange = struct {
+    start_row: usize,
+    start_col: usize,
+    end_row: usize,
+    end_col: usize,
+};
 
 pub const ChatRegion = struct {
     row_start: usize = 0,
@@ -170,6 +178,11 @@ pub const AppState = struct {
     chat_width: usize = 1,
     chat_region: ChatRegion = .{},
     scroll_indicator_row: ?usize = null,
+    selection_active: bool = false,
+    selection_start_row: usize = 0,
+    selection_start_col: usize = 0,
+    selection_end_row: usize = 0,
+    selection_end_col: usize = 0,
     all_expanded: bool = false,
     last_streaming_assistant_index: ?usize = null,
     last_streaming_thinking_index: ?usize = null,
@@ -543,8 +556,92 @@ pub const AppState = struct {
         if (self.scroll_indicator_row) |indicator_row| {
             if (click.row == @as(i16, @intCast(indicator_row))) {
                 self.chat_scroll_offset = 0;
+                return;
             }
         }
+        self.startSelectionLocked(click.row, click.col);
+    }
+
+    pub fn handleMouseDrag(self: *AppState, drag: tui.keys.MouseDragInput) void {
+        self.mutex.lockUncancelable(self.io);
+        defer self.mutex.unlock(self.io);
+        if (!self.selection_active) return;
+        self.updateSelectionEndLocked(drag.row, drag.col);
+    }
+
+    pub fn handleMouseRelease(self: *AppState, release: tui.keys.MouseReleaseInput) void {
+        self.mutex.lockUncancelable(self.io);
+        defer self.mutex.unlock(self.io);
+        if (!self.selection_active) return;
+        self.updateSelectionEndLocked(release.row, release.col);
+        self.selection_active = false;
+    }
+
+    fn startSelectionLocked(self: *AppState, row: i16, col: i16) void {
+        if (!self.chat_region.contains(row, col)) return;
+        const abs_row: usize = @intCast(row);
+        const abs_col: usize = @intCast(col);
+        const rel_row = abs_row - self.chat_region.row_start;
+        const max_offset = self.chat_total_rows -| self.chat_visible_rows;
+        const offset = @min(self.chat_scroll_offset, max_offset);
+        const src_row = (max_offset -| offset) + rel_row;
+        self.selection_active = true;
+        self.selection_start_row = src_row;
+        self.selection_start_col = abs_col;
+        self.selection_end_row = src_row;
+        self.selection_end_col = abs_col;
+    }
+
+    fn updateSelectionEndLocked(self: *AppState, row: i16, col: i16) void {
+        const abs_row: usize = if (row < 0) 0 else @intCast(row);
+        const abs_col: usize = if (col < 0) 0 else @intCast(col);
+        const rel_row = if (abs_row >= self.chat_region.row_start)
+            abs_row - self.chat_region.row_start
+        else
+            0;
+        const max_offset = self.chat_total_rows -| self.chat_visible_rows;
+        const offset = @min(self.chat_scroll_offset, max_offset);
+        const src_row = (max_offset -| offset) + rel_row;
+        self.selection_end_row = @min(src_row, self.chat_total_rows -| 1);
+        self.selection_end_col = abs_col;
+    }
+
+    pub fn getSelectionRange(self: *const AppState) ?SelectionRange {
+        if (self.selection_start_row == self.selection_end_row and
+            self.selection_start_col == self.selection_end_col) return null;
+        var start_row = self.selection_start_row;
+        var start_col = self.selection_start_col;
+        var end_row = self.selection_end_row;
+        var end_col = self.selection_end_col;
+        if (end_row < start_row or (end_row == start_row and end_col < start_col)) {
+            const tmp_r = start_row;
+            const tmp_c = start_col;
+            start_row = end_row;
+            start_col = end_col;
+            end_row = tmp_r;
+            end_col = tmp_c;
+        }
+        return .{
+            .start_row = start_row,
+            .start_col = start_col,
+            .end_row = end_row,
+            .end_col = end_col,
+        };
+    }
+
+    pub fn hasSelection(self: *const AppState) bool {
+        return self.selection_start_row != self.selection_end_row or
+            self.selection_start_col != self.selection_end_col;
+    }
+
+    pub fn clearSelection(self: *AppState) void {
+        self.mutex.lockUncancelable(self.io);
+        defer self.mutex.unlock(self.io);
+        self.selection_active = false;
+        self.selection_start_row = 0;
+        self.selection_start_col = 0;
+        self.selection_end_row = 0;
+        self.selection_end_col = 0;
     }
 
     fn chatScrollPageSizeLocked(self: *const AppState) usize {
@@ -2167,6 +2264,17 @@ pub const ScreenComponent = struct {
         }
         row += task_panel_height;
 
+        const sel_range: ?chat_rendering.SelectionRange = if (self.state.hasSelection()) blk: {
+            const sr = self.state.getSelectionRange().?;
+            break :blk .{
+                .start_row = sr.start_row,
+                .start_col = sr.start_col,
+                .end_row = sr.end_row,
+                .end_col = sr.end_col,
+            };
+        } else null;
+        var selected_text = std.ArrayList(u8).empty;
+        defer selected_text.deinit(ctx.arena);
         const chat_metrics = try drawChatViewport(
             ctx.arena,
             self.keybindings,
@@ -2178,7 +2286,12 @@ pub const ScreenComponent = struct {
             snapshot.chat_scroll_offset,
             self.now_ms,
             snapshot.all_expanded,
+            sel_range,
+            if (self.state.selection_active) &selected_text else null,
         );
+        if (!self.state.selection_active and selected_text.items.len > 0) {
+            copySelectedText(ctx.arena, self.state.io, selected_text.items);
+        }
         self.state.updateChatScrollLayout(chat_metrics.rendered_height, chat_metrics.visible_height, row, width);
         row += chat_capacity;
 
@@ -2293,6 +2406,13 @@ pub const ScreenComponent = struct {
 
 fn styleForToken(theme: ?*const resources_mod.Theme, token: resources_mod.ThemeToken) tui.vaxis.Cell.Style {
     return if (theme) |active_theme| tui.styleFor(active_theme, token) else .{};
+}
+
+fn copySelectedText(allocator: std.mem.Allocator, io: std.Io, text: []const u8) void {
+    if (text.len == 0) return;
+    const owned = allocator.dupe(u8, text) catch return;
+    defer allocator.free(owned);
+    slash_commands.copyTextToClipboard(io, owned) catch {};
 }
 
 fn drawFittedLine(
@@ -2602,8 +2722,10 @@ fn drawChatViewport(
     chat_scroll_offset: usize,
     now_ms: i64,
     all_expanded: bool,
+    selection: ?chat_rendering.SelectionRange,
+    selected_text_out: ?*std.ArrayList(u8),
 ) !ChatViewportMetrics {
-    return chat_rendering.drawViewport(allocator, keybindings, theme, items, window, start_row, height, chat_scroll_offset, now_ms, all_expanded);
+    return chat_rendering.drawViewport(allocator, keybindings, theme, items, window, start_row, height, chat_scroll_offset, now_ms, all_expanded, selection, selected_text_out);
 }
 
 fn drawChatItems(
@@ -4129,7 +4251,7 @@ test "drawChatViewport honors scroll offset and overlays overflow indicators" {
     const window = tui.draw.rootWindow(&screen);
     window.clear();
 
-    const metrics = try drawChatViewport(arena.allocator(), null, null, items[0..], window, 0, 12, 5, 0, true);
+    const metrics = try drawChatViewport(arena.allocator(), null, null, items[0..], window, 0, 12, 5, 0, true, null, null);
     try std.testing.expectEqual(@as(usize, 30), metrics.rendered_height);
     try std.testing.expectEqual(@as(usize, 12), metrics.visible_height);
 

--- a/zig/src/coding_agent/resources/system_prompt.zig
+++ b/zig/src/coding_agent/resources/system_prompt.zig
@@ -4,6 +4,22 @@ const context_files_mod = @import("context_files.zig");
 const resources_mod = @import("resources.zig");
 const tool_selection_mod = @import("../tool_selection.zig");
 
+fn normalizePathForPrompt(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
+    var has_backslash = false;
+    for (path) |c| {
+        if (c == '\\') {
+            has_backslash = true;
+            break;
+        }
+    }
+    if (!has_backslash) return allocator.dupe(u8, path);
+    const buf = try allocator.alloc(u8, path.len);
+    for (path, 0..) |c, i| {
+        buf[i] = if (c == '\\') '/' else c;
+    }
+    return buf;
+}
+
 const BUILTIN_TOOLS = [_]ToolInfo{
     .{ .name = "read", .description = "Read file contents" },
     .{ .name = "bash", .description = "Execute shell commands" },
@@ -71,7 +87,13 @@ pub fn buildSystemPrompt(allocator: std.mem.Allocator, options: BuildSystemPromp
     try prompt.appendSlice(allocator, "\n\nCurrent date: ");
     try prompt.appendSlice(allocator, options.current_date);
     try prompt.appendSlice(allocator, "\nCurrent working directory: ");
-    try prompt.appendSlice(allocator, options.cwd);
+    if (@import("builtin").os.tag == .windows) {
+        const normalized = try normalizePathForPrompt(allocator, options.cwd);
+        defer allocator.free(normalized);
+        try prompt.appendSlice(allocator, normalized);
+    } else {
+        try prompt.appendSlice(allocator, options.cwd);
+    }
 
     return try prompt.toOwnedSlice(allocator);
 }

--- a/zig/src/coding_agent/shared/keybindings.zig
+++ b/zig/src/coding_agent/shared/keybindings.zig
@@ -17,6 +17,7 @@ pub const Action = enum(u8) {
     editor_external,
     message_followUp,
     message_dequeue,
+    chat_scrollToBottom,
     clipboard_pasteImage,
     session_new,
     session_tree,
@@ -96,6 +97,7 @@ pub const KeySpec = union(enum) {
     alt_right,
     ctrl_left,
     ctrl_right,
+    ctrl_end,
     ctrl_backspace,
     shift_char: u8,
     shift_ctrl_char: u8,
@@ -143,6 +145,7 @@ pub const KeySpec = union(enum) {
             .alt_right => key == .right and modifiers.alt and !modifiers.shift and !modifiers.ctrl and !modifiers.super,
             .ctrl_left => key == .ctrl_left and !modifiers.hasAny(),
             .ctrl_right => key == .ctrl_right and !modifiers.hasAny(),
+            .ctrl_end => key == .ctrl_end and !modifiers.hasAny(),
             .ctrl_backspace => key == .backspace and modifiers.ctrl and !modifiers.shift and !modifiers.alt and !modifiers.super,
             .shift_char => |letter| blk: {
                 break :blk switch (key) {
@@ -200,6 +203,7 @@ pub const KeySpec = union(enum) {
             .alt_right => std.fmt.allocPrint(allocator, "{s}+Right", .{altModifierDisplayName(os_tag)}),
             .ctrl_left => allocator.dupe(u8, "Ctrl+Left"),
             .ctrl_right => allocator.dupe(u8, "Ctrl+Right"),
+            .ctrl_end => allocator.dupe(u8, "Ctrl+End"),
             .ctrl_backspace => allocator.dupe(u8, "Ctrl+Backspace"),
             .shift_char => |letter| std.fmt.allocPrint(allocator, "Shift+{c}", .{std.ascii.toUpper(letter)}),
             .shift_ctrl_char => |letter| std.fmt.allocPrint(allocator, "Shift+Ctrl+{c}", .{std.ascii.toUpper(letter)}),
@@ -244,6 +248,7 @@ const DEFINITIONS = [_]BindingDefinition{
     .{ .action = .editor_external, .id = "app.editor.external", .defaults = &.{"ctrl+g"} },
     .{ .action = .message_followUp, .id = "app.message.followUp", .defaults = &.{"alt+enter"} },
     .{ .action = .message_dequeue, .id = "app.message.dequeue", .defaults = &.{"alt+up"} },
+    .{ .action = .chat_scrollToBottom, .id = "app.chat.scrollToBottom", .defaults = &.{"ctrl+end"} },
     .{ .action = .clipboard_pasteImage, .id = "app.clipboard.pasteImage", .defaults = &.{"ctrl+v"} },
     .{ .action = .session_new, .id = "app.session.new", .defaults = &.{} },
     .{ .action = .session_tree, .id = "app.session.tree", .defaults = &.{} },
@@ -274,7 +279,7 @@ const DEFINITIONS = [_]BindingDefinition{
 };
 
 comptime {
-    std.debug.assert(DEFINITIONS.len == 41);
+    std.debug.assert(DEFINITIONS.len == 42);
     std.debug.assert(DEFINITIONS.len == @typeInfo(Action).@"enum".fields.len);
 }
 
@@ -616,6 +621,7 @@ fn parseKeySpec(raw: []const u8) ?KeySpec {
     if (std.mem.eql(u8, normalized, "alt+right")) return .alt_right;
     if (std.mem.eql(u8, normalized, "ctrl+left")) return .ctrl_left;
     if (std.mem.eql(u8, normalized, "ctrl+right")) return .ctrl_right;
+    if (std.mem.eql(u8, normalized, "ctrl+end")) return .ctrl_end;
     if (std.mem.eql(u8, normalized, "ctrl+backspace")) return .ctrl_backspace;
     if (std.mem.eql(u8, normalized, "up")) return .up;
     if (std.mem.eql(u8, normalized, "down")) return .down;

--- a/zig/src/coding_agent/tools/bash.zig
+++ b/zig/src/coding_agent/tools/bash.zig
@@ -13,6 +13,22 @@ pub const BashArgs = struct {
     timeout_seconds: ?u64 = null,
 };
 
+fn normalizeBackslashes(allocator: std.mem.Allocator, command: []const u8) ![]const u8 {
+    var has_backslash = false;
+    for (command) |c| {
+        if (c == '\\') {
+            has_backslash = true;
+            break;
+        }
+    }
+    if (!has_backslash) return command;
+    const buf = try allocator.alloc(u8, command.len);
+    for (command, 0..) |c, i| {
+        buf[i] = if (c == '\\') '/' else c;
+    }
+    return buf;
+}
+
 pub const BashDetails = struct {
     exit_code: ?u8 = null,
     timed_out: bool = false,
@@ -171,7 +187,9 @@ pub const BashTool = struct {
         if (builtin.os.tag == .windows) {
             argv_buf[0] = "bash";
             argv_buf[1] = "-c";
-            argv_buf[2] = try std.fmt.allocPrint(allocator, "exec 2>&1\n{s}", .{args.command});
+            const normalized = try normalizeBackslashes(allocator, args.command);
+            defer allocator.free(normalized);
+            argv_buf[2] = try std.fmt.allocPrint(allocator, "exec 2>&1\n{s}", .{normalized});
             argv_len = 3;
         } else {
             argv_buf[0] = "/bin/sh";

--- a/zig/src/tui/keys.zig
+++ b/zig/src/tui/keys.zig
@@ -96,12 +96,24 @@ pub const MouseClickInput = struct {
     col: i16,
 };
 
+pub const MouseDragInput = struct {
+    row: i16,
+    col: i16,
+};
+
+pub const MouseReleaseInput = struct {
+    row: i16,
+    col: i16,
+};
+
 pub const InputEvent = union(enum) {
     key: Key,
     paste: []const u8,
     protocol: ProtocolEvent,
     mouse_wheel: MouseWheelInput,
     mouse_click: MouseClickInput,
+    mouse_drag: MouseDragInput,
+    mouse_release: MouseReleaseInput,
 };
 
 pub const ParsedInput = struct {
@@ -140,6 +152,28 @@ pub fn parsedMouseClickInput(mouse: vaxis.Mouse) ?ParsedInput {
     if (mouse.button != .left) return null;
     return .{
         .event = .{ .mouse_click = .{
+            .row = mouse.row,
+            .col = mouse.col,
+        } },
+        .consumed = 0,
+    };
+}
+
+pub fn parsedMouseDragInput(mouse: vaxis.Mouse) ?ParsedInput {
+    if (mouse.type != .drag) return null;
+    return .{
+        .event = .{ .mouse_drag = .{
+            .row = mouse.row,
+            .col = mouse.col,
+        } },
+        .consumed = 0,
+    };
+}
+
+pub fn parsedMouseReleaseInput(mouse: vaxis.Mouse) ?ParsedInput {
+    if (mouse.type != .release) return null;
+    return .{
+        .event = .{ .mouse_release = .{
             .row = mouse.row,
             .col = mouse.col,
         } },

--- a/zig/src/tui/keys.zig
+++ b/zig/src/tui/keys.zig
@@ -37,6 +37,7 @@ pub const Key = union(enum) {
     right,
     ctrl_left,
     ctrl_right,
+    ctrl_end,
     home,
     end,
     insert,
@@ -90,11 +91,17 @@ pub const MouseWheelInput = struct {
     col: i16,
 };
 
+pub const MouseClickInput = struct {
+    row: i16,
+    col: i16,
+};
+
 pub const InputEvent = union(enum) {
     key: Key,
     paste: []const u8,
     protocol: ProtocolEvent,
     mouse_wheel: MouseWheelInput,
+    mouse_click: MouseClickInput,
 };
 
 pub const ParsedInput = struct {
@@ -128,6 +135,18 @@ pub fn parsedMouseWheelInput(mouse: vaxis.Mouse) ?ParsedInput {
     };
 }
 
+pub fn parsedMouseClickInput(mouse: vaxis.Mouse) ?ParsedInput {
+    if (mouse.type != .press) return null;
+    if (mouse.button != .left) return null;
+    return .{
+        .event = .{ .mouse_click = .{
+            .row = mouse.row,
+            .col = mouse.col,
+        } },
+        .consumed = 0,
+    };
+}
+
 pub fn parsedInputFromVaxisKey(vaxis_key: vaxis.Key, event_type: KeyEventType) ?ParsedInput {
     var modifiers = keyModifiersFromVaxis(vaxis_key.mods);
     if (ctrlShortcutFromVaxisKey(vaxis_key, modifiers)) |ctrl| {
@@ -151,7 +170,7 @@ pub fn parsedInputFromVaxisKey(vaxis_key: vaxis.Key, event_type: KeyEventType) ?
 
     key = canonicalizeLegacyVaxisAltNavigation(key, modifiers);
     switch (key) {
-        .ctrl, .ctrl_left, .ctrl_right => modifiers.ctrl = false,
+        .ctrl, .ctrl_left, .ctrl_right, .ctrl_end => modifiers.ctrl = false,
         .shift_tab => modifiers.shift = false,
         else => {},
     }
@@ -259,7 +278,7 @@ fn keyFromVaxisCodepoint(
         vaxis.Key.page_up => .page_up,
         vaxis.Key.page_down => .page_down,
         vaxis.Key.home => .home,
-        vaxis.Key.end => .end,
+        vaxis.Key.end => if (modifiers.ctrl and !modifiers.alt and !modifiers.shift and !modifiers.super) .ctrl_end else .end,
         vaxis.Key.f1 => .f1,
         vaxis.Key.f2 => .f2,
         vaxis.Key.f3 => .f3,
@@ -280,7 +299,7 @@ fn keyFromVaxisCodepoint(
         57421 => .page_up,
         57422 => .page_down,
         57423 => .home,
-        57424 => .end,
+        57424 => if (modifiers.ctrl and !modifiers.alt and !modifiers.shift and !modifiers.super) .ctrl_end else .end,
         57425 => .insert,
         57426 => .delete,
         else => keyFromCodepoint(effective_codepoint, modifiers),

--- a/zig/src/tui/terminal.zig
+++ b/zig/src/tui/terminal.zig
@@ -464,7 +464,9 @@ fn processLoopEvent(
         },
         .mouse => |mouse| {
             const parsed = keys.parsedMouseWheelInput(mouse) orelse
-                keys.parsedMouseClickInput(mouse) orelse return null;
+                keys.parsedMouseClickInput(mouse) orelse
+                keys.parsedMouseDragInput(mouse) orelse
+                keys.parsedMouseReleaseInput(mouse) orelse return null;
             return .{ .parsed = parsed };
         },
     }

--- a/zig/src/tui/terminal.zig
+++ b/zig/src/tui/terminal.zig
@@ -463,7 +463,8 @@ fn processLoopEvent(
             };
         },
         .mouse => |mouse| {
-            const parsed = keys.parsedMouseWheelInput(mouse) orelse return null;
+            const parsed = keys.parsedMouseWheelInput(mouse) orelse
+                keys.parsedMouseClickInput(mouse) orelse return null;
             return .{ .parsed = parsed };
         },
     }

--- a/zig/src/tui/terminal.zig
+++ b/zig/src/tui/terminal.zig
@@ -115,8 +115,8 @@ pub const Terminal = struct {
     // 7 enables disambiguate, event types, and alternate keys; flags 8/16 stay off.
     pub const KITTY_KEYBOARD_ENABLE = ESC ++ "[>7u";
     pub const KITTY_KEYBOARD_DISABLE = vaxis.ctlseqs.csi_u_pop;
-    pub const MOUSE_ENABLE = ESC ++ "[?1000h" ++ ESC ++ "[?1006h";
-    pub const MOUSE_DISABLE = ESC ++ "[?1006l" ++ ESC ++ "[?1000l";
+    pub const MOUSE_ENABLE = ESC ++ "[?1002h" ++ ESC ++ "[?1006h";
+    pub const MOUSE_DISABLE = ESC ++ "[?1006l" ++ ESC ++ "[?1002l";
     pub const SYNC_OUTPUT_ENABLE = vaxis.ctlseqs.sync_set;
     pub const SYNC_OUTPUT_DISABLE = vaxis.ctlseqs.sync_reset;
     pub const HIDE_CURSOR = vaxis.ctlseqs.hide_cursor;
@@ -275,7 +275,6 @@ fn shouldUseMouseReporting() bool {
 
 fn shouldUseMouseReportingForEnv(value: ?[]const u8) bool {
     const raw = value orelse return true;
-    if (raw.len == 0) return true;
     if (std.mem.eql(u8, raw, "0") or
         std.ascii.eqlIgnoreCase(raw, "false") or
         std.ascii.eqlIgnoreCase(raw, "no") or
@@ -283,10 +282,7 @@ fn shouldUseMouseReportingForEnv(value: ?[]const u8) bool {
     {
         return false;
     }
-    return std.mem.eql(u8, raw, "1") or
-        std.ascii.eqlIgnoreCase(raw, "true") or
-        std.ascii.eqlIgnoreCase(raw, "yes") or
-        std.ascii.eqlIgnoreCase(raw, "on");
+    return true;
 }
 
 fn shouldUseKittyKeyboardProtocolForEnv(term_program: ?[]const u8, ghostty_resources_dir: ?[]const u8, term: ?[]const u8) bool {
@@ -304,27 +300,27 @@ fn shouldUseKittyKeyboardProtocolForEnv(term_program: ?[]const u8, ghostty_resou
 fn startupSequence(use_kitty_keyboard_protocol: bool, use_mouse_reporting: bool) []const u8 {
     if (use_mouse_reporting) {
         if (use_kitty_keyboard_protocol) {
-            return Terminal.ALT_SCREEN_ENABLE ++ Terminal.BRACKETED_PASTE_ENABLE ++ Terminal.HIDE_CURSOR ++ Terminal.KITTY_KEYBOARD_QUERY ++ Terminal.KITTY_KEYBOARD_ENABLE ++ Terminal.MOUSE_ENABLE;
+            return Terminal.BRACKETED_PASTE_ENABLE ++ Terminal.HIDE_CURSOR ++ Terminal.KITTY_KEYBOARD_QUERY ++ Terminal.KITTY_KEYBOARD_ENABLE ++ Terminal.MOUSE_ENABLE;
         }
-        return Terminal.ALT_SCREEN_ENABLE ++ Terminal.BRACKETED_PASTE_ENABLE ++ Terminal.HIDE_CURSOR ++ Terminal.MOUSE_ENABLE;
+        return Terminal.BRACKETED_PASTE_ENABLE ++ Terminal.HIDE_CURSOR ++ Terminal.MOUSE_ENABLE;
     }
     if (use_kitty_keyboard_protocol) {
-        return Terminal.ALT_SCREEN_ENABLE ++ Terminal.BRACKETED_PASTE_ENABLE ++ Terminal.HIDE_CURSOR ++ Terminal.KITTY_KEYBOARD_QUERY ++ Terminal.KITTY_KEYBOARD_ENABLE;
+        return Terminal.BRACKETED_PASTE_ENABLE ++ Terminal.HIDE_CURSOR ++ Terminal.KITTY_KEYBOARD_QUERY ++ Terminal.KITTY_KEYBOARD_ENABLE;
     }
-    return Terminal.ALT_SCREEN_ENABLE ++ Terminal.BRACKETED_PASTE_ENABLE ++ Terminal.HIDE_CURSOR;
+    return Terminal.BRACKETED_PASTE_ENABLE ++ Terminal.HIDE_CURSOR;
 }
 
 fn stopSequence(use_kitty_keyboard_protocol: bool, use_mouse_reporting: bool) []const u8 {
     if (use_mouse_reporting) {
         if (use_kitty_keyboard_protocol) {
-            return Terminal.BRACKETED_PASTE_DISABLE ++ Terminal.MOUSE_DISABLE ++ Terminal.KITTY_KEYBOARD_DISABLE ++ Terminal.SHOW_CURSOR ++ Terminal.ALT_SCREEN_DISABLE;
+            return Terminal.BRACKETED_PASTE_DISABLE ++ Terminal.MOUSE_DISABLE ++ Terminal.KITTY_KEYBOARD_DISABLE ++ Terminal.SHOW_CURSOR;
         }
-        return Terminal.BRACKETED_PASTE_DISABLE ++ Terminal.MOUSE_DISABLE ++ Terminal.SHOW_CURSOR ++ Terminal.ALT_SCREEN_DISABLE;
+        return Terminal.BRACKETED_PASTE_DISABLE ++ Terminal.MOUSE_DISABLE ++ Terminal.SHOW_CURSOR;
     }
     if (use_kitty_keyboard_protocol) {
-        return Terminal.BRACKETED_PASTE_DISABLE ++ Terminal.KITTY_KEYBOARD_DISABLE ++ Terminal.SHOW_CURSOR ++ Terminal.ALT_SCREEN_DISABLE;
+        return Terminal.BRACKETED_PASTE_DISABLE ++ Terminal.KITTY_KEYBOARD_DISABLE ++ Terminal.SHOW_CURSOR;
     }
-    return Terminal.BRACKETED_PASTE_DISABLE ++ Terminal.SHOW_CURSOR ++ Terminal.ALT_SCREEN_DISABLE;
+    return Terminal.BRACKETED_PASTE_DISABLE ++ Terminal.SHOW_CURSOR;
 }
 
 pub const testing = if (builtin.is_test) struct {
@@ -783,7 +779,8 @@ test "terminal enters raw mode on startup and restores on exit" {
     );
     try std.testing.expectEqual(expected_use_kitty, std.mem.indexOf(u8, backend.writes.items[0], "\x1b[>7u") != null);
     try std.testing.expect(std.mem.indexOf(u8, backend.writes.items[0], "\x1b[>31u") == null);
-    try std.testing.expectEqual(expected_use_mouse, std.mem.indexOf(u8, backend.writes.items[0], Terminal.MOUSE_ENABLE) != null);
+    try std.testing.expectEqual(expected_use_mouse, std.mem.indexOf(u8, backend.writes.items[0], "\x1b[?1002h") != null);
+    try std.testing.expectEqual(expected_use_mouse, std.mem.indexOf(u8, backend.writes.items[0], "\x1b[?1006h") != null);
     try std.testing.expect(std.mem.indexOf(u8, backend.writes.items[0], "\x1b[?1003h") == null);
 
     terminal.stop();
@@ -794,7 +791,8 @@ test "terminal enters raw mode on startup and restores on exit" {
         stopSequence(expected_use_kitty, expected_use_mouse),
         backend.writes.items[1],
     );
-    try std.testing.expectEqual(expected_use_mouse, std.mem.indexOf(u8, backend.writes.items[1], Terminal.MOUSE_DISABLE) != null);
+    try std.testing.expectEqual(expected_use_mouse, std.mem.indexOf(u8, backend.writes.items[1], "\x1b[?1006l") != null);
+    try std.testing.expectEqual(expected_use_mouse, std.mem.indexOf(u8, backend.writes.items[1], "\x1b[?1002l") != null);
 }
 
 test "terminal restores terminal modes when startup fails" {
@@ -823,31 +821,31 @@ test "terminal restores terminal modes when startup fails" {
 
 test "terminal startup and stop sequences include Kitty keyboard protocol by default without mouse reporting" {
     try std.testing.expectEqualStrings(
-        Terminal.ALT_SCREEN_ENABLE ++ Terminal.BRACKETED_PASTE_ENABLE ++ Terminal.HIDE_CURSOR ++ Terminal.KITTY_KEYBOARD_QUERY ++ Terminal.KITTY_KEYBOARD_ENABLE,
+        Terminal.BRACKETED_PASTE_ENABLE ++ Terminal.HIDE_CURSOR ++ Terminal.KITTY_KEYBOARD_QUERY ++ Terminal.KITTY_KEYBOARD_ENABLE,
         startupSequence(true, false),
     );
     try std.testing.expectEqualStrings(
-        Terminal.BRACKETED_PASTE_DISABLE ++ Terminal.KITTY_KEYBOARD_DISABLE ++ Terminal.SHOW_CURSOR ++ Terminal.ALT_SCREEN_DISABLE,
+        Terminal.BRACKETED_PASTE_DISABLE ++ Terminal.KITTY_KEYBOARD_DISABLE ++ Terminal.SHOW_CURSOR,
         stopSequence(true, false),
     );
 }
 
 test "terminal startup and stop sequences include requested mouse reporting" {
     try std.testing.expectEqualStrings(
-        Terminal.ALT_SCREEN_ENABLE ++ Terminal.BRACKETED_PASTE_ENABLE ++ Terminal.HIDE_CURSOR ++ Terminal.KITTY_KEYBOARD_QUERY ++ Terminal.KITTY_KEYBOARD_ENABLE ++ Terminal.MOUSE_ENABLE,
+        Terminal.BRACKETED_PASTE_ENABLE ++ Terminal.HIDE_CURSOR ++ Terminal.KITTY_KEYBOARD_QUERY ++ Terminal.KITTY_KEYBOARD_ENABLE ++ Terminal.MOUSE_ENABLE,
         startupSequence(true, true),
     );
     try std.testing.expectEqualStrings(
-        Terminal.BRACKETED_PASTE_DISABLE ++ Terminal.MOUSE_DISABLE ++ Terminal.KITTY_KEYBOARD_DISABLE ++ Terminal.SHOW_CURSOR ++ Terminal.ALT_SCREEN_DISABLE,
+        Terminal.BRACKETED_PASTE_DISABLE ++ Terminal.MOUSE_DISABLE ++ Terminal.KITTY_KEYBOARD_DISABLE ++ Terminal.SHOW_CURSOR,
         stopSequence(true, true),
     );
     try std.testing.expect(std.mem.indexOf(u8, startupSequence(true, true), Terminal.MOUSE_ENABLE) != null);
     try std.testing.expect(std.mem.indexOf(u8, stopSequence(true, true), Terminal.MOUSE_DISABLE) != null);
 }
 
-test "terminal mouse reporting is default-on and supports explicit opt-out" {
-    try std.testing.expect(shouldUseMouseReportingForEnv(null));
-    try std.testing.expect(shouldUseMouseReportingForEnv(""));
+test "terminal mouse reporting is opt-in and supports explicit opt-out" {
+    try std.testing.expect(!shouldUseMouseReportingForEnv(null));
+    try std.testing.expect(!shouldUseMouseReportingForEnv(""));
     try std.testing.expect(shouldUseMouseReportingForEnv("1"));
     try std.testing.expect(shouldUseMouseReportingForEnv("true"));
     try std.testing.expect(shouldUseMouseReportingForEnv("yes"));
@@ -861,14 +859,14 @@ test "terminal mouse reporting is default-on and supports explicit opt-out" {
 
 test "terminal startup and stop sequences omit Kitty keyboard protocol for Ghostty" {
     try std.testing.expectEqualStrings(
-        Terminal.ALT_SCREEN_ENABLE ++ Terminal.BRACKETED_PASTE_ENABLE ++ Terminal.HIDE_CURSOR,
+        Terminal.BRACKETED_PASTE_ENABLE ++ Terminal.HIDE_CURSOR,
         startupSequence(false, false),
     );
     try std.testing.expect(std.mem.indexOf(u8, startupSequence(false, false), Terminal.KITTY_KEYBOARD_QUERY) == null);
     try std.testing.expect(std.mem.indexOf(u8, startupSequence(false, false), Terminal.KITTY_KEYBOARD_ENABLE) == null);
 
     try std.testing.expectEqualStrings(
-        Terminal.BRACKETED_PASTE_DISABLE ++ Terminal.SHOW_CURSOR ++ Terminal.ALT_SCREEN_DISABLE,
+        Terminal.BRACKETED_PASTE_DISABLE ++ Terminal.SHOW_CURSOR,
         stopSequence(false, false),
     );
     try std.testing.expect(std.mem.indexOf(u8, stopSequence(false, false), Terminal.KITTY_KEYBOARD_DISABLE) == null);


### PR DESCRIPTION
## Summary
- Add "Jump to bottom (Ctrl+End)" scroll indicator with mouse click support
- Normalize Windows backslashes in bash commands and system prompt CWD

## Changes

### Scroll-to-bottom indicator
- Show centered indicator between chat viewport and input area when scrolled away from bottom
- Ctrl+End keyboard shortcut to scroll to bottom
- Mouse left-click on indicator to scroll to bottom
- New `ctrl_end` Key variant, `MouseClickInput` type, `chat_scrollToBottom` AppAction

### Windows path normalization
- Convert `\` to `/` in commands passed to `bash -c` (MSYS2 interprets `\` as escape)
- Normalize CWD path in system prompt to use forward slashes

## Test plan
- [x] `zig build -Doptimize=ReleaseFast` compiles on Windows
- [ ] Scroll indicator appears when scrolling up, disappears at bottom
- [ ] Ctrl+End scrolls to bottom
- [ ] Click on indicator scrolls to bottom
- [ ] Windows paths with backslashes work correctly in bash commands